### PR TITLE
The data series it now in javascript format

### DIFF
--- a/nvd3/NVD3Chart.py
+++ b/nvd3/NVD3Chart.py
@@ -12,6 +12,7 @@ Project location : https://github.com/areski/python-nvd3
 from optparse import OptionParser
 from string import Template
 import random
+import json
 
 template_page_nvd3 = """
 <!DOCTYPE html>
@@ -365,7 +366,8 @@ class NVD3Chart:
         self.jschart += stab(1) + "return chart;\n});\n"
 
         #Include data
-        self.jschart += """data_%s=%s;\n</script>""" % (self.name, self.series)
+        series_js = json.dumps(self.series)
+        self.jschart += """data_%s=%s;\n</script>""" % (self.name, series_js)
 
     def create_x_axis(self, name, label=None, format=None, date=False):
         """


### PR DESCRIPTION
The data series (self.series) was in python format, in example:

```
{'y': 6, 'x': 1338501600000L}
```

Now it's in javascript format, in example:

```
{'y': 6, 'x': 1338501600000}
```

The default examples (linechart, linewithfocuschart) were failing ('Uncaught SyntaxError: Unexpected token ILLEGAL') because of the invalid js.
