### PR TITLE
Remove x-axis sorting

### DIFF
--- a/nvd3/NVD3Chart.py
+++ b/nvd3/NVD3Chart.py
@@ -164,7 +164,6 @@ class NVD3Chart:
         if self.x_axis_date:
             x = [str(d) for d in x]
 
-        x = sorted(x)
         # For scatterChart shape & size fields are added in serie
         if 'shape' in kwargs:
             serie = [{"x": x[i], "y": y, "shape": kwargs["shape"], "size": random.randint(1, 3)} for i, y in enumerate(y)]


### PR DESCRIPTION
Sorting the x-axis ruins the mapping between the ydata and xdata lists.
