### PR TITLE
ScatterPlot - added variable size

### DIFF
--- a/nvd3/NVD3Chart.py
+++ b/nvd3/NVD3Chart.py
@@ -179,7 +179,7 @@ class NVD3Chart:
             serie =[{
                 "x": x[i], 
                 "y": y, 
-                "shape": shape, 
+                "shape": cshape, 
                 "size": csize[i] if isinstance(csize, list) else csize
                 } for i, y in enumerate(y)]
         else:


### PR DESCRIPTION
ScatterPlots previously only supported a fixed/random size for points. This has been changed to support per-point variable size allowing for a third variable to be plotted along with the usual x, y variables.

The code permits either a series of sizes to be added, or for the size to be fixed for the whole series. From a statistical point of view, having fixed sizes for the points is preferable as, in my view, the current randomisation of point size suggests they represent a variable on the graph.
