### PR TITLE
Add python wrapper classes for generating javascript

### DIFF
--- a/nvd3/translator.py
+++ b/nvd3/translator.py
@@ -11,7 +11,10 @@ class Tag(object):
                                for attr, value in self.attrs])
 
     def __str__(self):
-        return '<%s%s>\n    %s\n</%s>' % (self.name, self.attrs and ' ' + self.attrs or '', self.content, self.name)
+        return '<%s%s>\n    %s\n</%s>' % (self.name,
+                                          ' ' + self.attrs if self.attrs else '',
+                                          self.content,
+                                          self.name)
 
 
 class ScriptTag(Tag):
@@ -32,22 +35,23 @@ class Function(object):
 
     def __init__(self, name):
         self.name = name
-        self.statements = []
+        self._calls = []
 
     def __str__(self):
         operations = [self.name]
-        operations.extend(str(statement) for statement in self.statements)
+        operations.extend(str(call) for call in self._calls)
         return '%s' % ('.'.join(operations),)
 
     def __getattr__(self, attr):
-        self.statements.append(attr)
+        self._calls.append(attr)
         return self
 
-    def __call__(self, args=None):
-        if isinstance(args, (Function, AnonymousFunction, basestring)):
-            self.statements[-1] = self.statements[-1] + '(%s)' % (args,)
+    def __call__(self, *args):
+        if not args:
+            self._calls[-1] = self._calls[-1] + '()'
         else:
-            self.statements[-1] = self.statements[-1] + '()'
+            arguments = ','.join([str(arg) for arg in args])
+            self._calls[-1] = self._calls[-1] + '(%s)' % (arguments,)
         return self
 
 
@@ -59,19 +63,9 @@ class Assignment(object):
         self.scoped = scoped
 
     def __str__(self):
-        return '%s%s = %s;' % (self.scoped and 'var ' or '', self.key, self.value)
+        return '%s%s = %s;' % ('var ' if self.scoped else '', self.key, self.value)
 
 
-if __name__ == '__main__':
-    nv = Function('nv').addGraph(
-        AnonymousFunction('', Assignment('chart',
-            Function('nv').models.pieChart(
-                ).x(
-                    AnonymousFunction('d', 'return d.label;')
-                ).y(
-                    AnonymousFunction('d', 'return d.value;')
-                ).showLabels('true')
-            )
-        )
-    )
-    print nv
+def indent(func):
+    # TODO: Add indents to function str
+    return str(func)

--- a/tests.py
+++ b/tests.py
@@ -11,6 +11,7 @@ from nvd3 import scatterChart
 from nvd3 import discreteBarChart
 from nvd3 import pieChart
 from nvd3 import multiBarChart
+from nvd3.translator import Function, AnonymousFunction, Assignment
 import random
 import unittest
 import datetime
@@ -146,6 +147,26 @@ class ChartTest(unittest.TestCase):
         ydata = [3, 4, 0, 1, 5, 7, 3]
         chart.add_serie(y=ydata, x=xdata)
         chart.buildhtml()
+
+
+class TranslatorTest(unittest.TestCase):
+
+    def test_pieChart(self):
+        func = Function('nv').addGraph(
+            AnonymousFunction('', Assignment('chart',
+                Function('nv').models.pieChart(
+                    ).x(
+                        AnonymousFunction('d', 'return d.label;')
+                    ).y(
+                        AnonymousFunction('d', 'return d.value;')
+                    ).showLabels('true')
+                )
+            )
+        )
+        self.assertEqual(str(func),
+                         'nv.addGraph(function() { var chart = '
+                         'nv.models.pieChart().x(function(d) { return d.label; '
+                         '}).y(function(d) { return d.value; }).showLabels(true); })')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I added some classes for generating javascript strings: `Function` corresponds to function which can has chainable calls, `AnnoymousFunction` corresponds to `function(x) { y }`, `Assignment` generates `var x = y`, but all of them have no indentions.

If the project use jinja2 or other templates engines, I do not think they can be well tested, so I try to add these functions.
