### PR TITLE
add color_list attribute so it gets kwargs

### DIFF
--- a/nvd3/NVD3Chart.py
+++ b/nvd3/NVD3Chart.py
@@ -117,6 +117,7 @@ class NVD3Chart:
         self.name = kwargs.get('name', self.model)
         self.jquery_on_ready = kwargs.get('jquery_on_ready', False)
         self.color_category = kwargs.get('color_category', None)
+        self.color_list = kwargs.get('color_list', None)
         self.stacked = kwargs.get('stacked', False)
         self.resize = kwargs.get('resize', False)
         self.show_legend = kwargs.get("show_legend", True)


### PR DESCRIPTION
If I have this right you can add a customise color list as per you code.  It just needs to init using the supplied value.

I was wondering if there is a way of getting the used color values when you  use a built in like category20c.  The use case, I would like to create a pie chart and use category20c (say 15 items) and THEN use the resulting colors for a pie chart (say 200 items) which is classified as per the pie chart.  Hope this makes sense.
