### PR TITLE
Custom chart attribute

### DIFF
--- a/nvd3/NVD3Chart.py
+++ b/nvd3/NVD3Chart.py
@@ -126,7 +126,7 @@ class NVD3Chart:
         self.show_legend = kwargs.get('show_legend', True)
         self.show_labels = kwargs.get('show_labels', True)
         self.tag_script_js = kwargs.get('tag_script_js', True)
-        self.chart_attr = kwargs.get("chart_attr", None)
+        self.chart_attr = kwargs.get("chart_attr", {})
         self.assets_directory = kwargs.get('assets_directory', './bower_components/')
 
         #CDN http://cdnjs.com/libraries/nvd3/ needs to make sure it's up to date


### PR DESCRIPTION
This is to allow users to pass a custom chart attribute, which is not yet hardcoded in python-nvd3.
Example:
char_attr = {'xScale':'(d3.scale.log())', 'xAxis.tickValues':'[0.001, 0.01, 0.1, 1, 10, 100]'}
will allow displaying a lineChart with log X axis and tick values shown in the list.

I also implemented this in django-nvd3.
