### PR TITLE
Allowing other shapes for scatteredPlot

### DIFF
--- a/nvd3/NVD3Chart.py
+++ b/nvd3/NVD3Chart.py
@@ -415,6 +415,11 @@ class NVD3Chart:
         self.build_custom_tooltip()
         self.jschart += self.charttooltip
 
+        # the shape attribute in kwargs is not applied when 
+        # not allowing other shapes to be rendered 
+        if self.model == 'scatterChart':
+           self.jschart += 'chart.scatter.onlyCircles(false);'
+
         if self.model != 'discreteBarChart':
             if self.show_legend:
                 self.jschart += stab(2) + "chart.showLegend(true);\n"


### PR DESCRIPTION
When using other shapes than circels for the scatteredPlot, the setting was not actually applied. Now setting chart.scatter.onlyCircles(false) when the javascipt is built, fixes the problem.
