### PR TITLE
Allow easier customizing of the y-axis formats

### DIFF
--- a/nvd3/linePlusBarChart.py
+++ b/nvd3/linePlusBarChart.py
@@ -101,11 +101,28 @@ class linePlusBarChart(NVD3Chart):
                 .call(chart);
             return chart;
         });
+
+
+    In case you have two data serie with extreme different numbers, that you would like to format
+    in different ways, you can pass a keyword *yaxis1_format* or *yaxis2_format* when
+    creating the graph::
+
+
+        ydata = [6, 5, 1]
+        y2data = [0.002, 0.003, 0.004]
+        chart = linePlusBarChart(name='linePlusBarChart',
+                                 yaxis2_format="function(d) { return d3.format(',0.3f')(d) }")
+
+    This way the graph create will represent the values of data series with three digits right
+    of the decimal point.
+
     """
     def __init__(self, **kwargs):
         NVD3Chart.__init__(self, **kwargs)
         height = kwargs.get('height', 450)
         width = kwargs.get('width', None)
+        self.yaxis1_format = kwargs.get('yaxis1_format', "function(d) { return d3.format(',f')(d) }")
+        self.yaxis2_format = kwargs.get('yaxis2_format', "function(d) { return d3.format(',f')(d) }")
 
         if kwargs.get('x_is_date', False):
             self.set_date_flag(True)
@@ -116,8 +133,8 @@ class linePlusBarChart(NVD3Chart):
         else:
             self.create_x_axis('xAxis', format=kwargs.get('x_axis_format', '.2f'))
 
-        self.create_y_axis('y1Axis', format="f")
-        self.create_y_axis('y2Axis', format="function(d) { return d3.format(',f')(d) }", custom_format=True)
+        self.create_y_axis('y1Axis', format=self.yaxis1_format, custom_format=True)
+        self.create_y_axis('y2Axis', format=self.yaxis2_format, custom_format=True)
 
         # must have a specified height, otherwise it superimposes both chars
         if height:


### PR DESCRIPTION
This is especially useful if you have a line
and bar chart with two data series with extreme differences.
Such as:

```
data_y1 = [10, 13, 14, 20]
data_y2 = [0.0003, 0.0032, 0.0057, 0.0081]
```

In the above case one may one would like to format the first
y axis with:

```
    cart.y1Axis
                .tickFormat(d3.format(',f'));
```

and the second y axis with:

```
    chart.y2Axis
                .tickFormat(function(d) {
                 return d3.format(',0.4f')(d) });
```

This is now possible with passing a keyword `yaxis2_format`
when creating a new ```linePlusBarChart`:

```
chart = linePlusBarChart(name="linePlusBarChart",
                         width=500, height=400, x_axis_format=None,
                         yaxis2_format="function(d) { return d3.format(',0.4f')(d) }")
```

To see a working example of the produces js check this jsfiddle: http://jsfiddle.net/oz123/XvPhg/6/
