### PR TITLE
Fixed ipynb.py

### DIFF
--- a/nvd3/ipynb.py
+++ b/nvd3/ipynb.py
@@ -26,9 +26,8 @@ if _ip and _ip.__module__.startswith('IPython'):
             initialize_javascript()
             import time
             time.sleep(5)
-        chart.buildcontainer()
-        chart.buildjschart()
-        return chart.container + chart.jschart
+        chart.buildhtml()
+        return chart.htmlcontent
 
     def _setup_ipython_formatter(ip):
         ''' Set up the ipython formatter to display HTML formatted output inline'''


### PR DESCRIPTION
Changed return value of _print_html() from chart.container + chart.jschart to chart.htmlcontent, since chart.buildjschart() no longer generates chart.jschart. Tested examples from http://nbviewer.ipython.org/gist/jdavidheiser/9552624 in IPython notebook v2.3.1 and found all charts rendered properly with this fix.