### PR TITLE
Add simplejson to imports

### DIFF
--- a/nvd3/NVD3Chart.py
+++ b/nvd3/NVD3Chart.py
@@ -13,7 +13,9 @@ from __future__ import unicode_literals
 from optparse import OptionParser
 from jinja2 import Environment, PackageLoader
 from slugify import slugify
-import json
+
+try: import simplejson as json
+except ImportError: import json
 
 
 CONTENT_FILENAME = "./content.html"


### PR DESCRIPTION
Since `simplejson` does support encoding `decimal.Decimal` out of the box....