### PR TITLE
Update for jupyter compatibility

### DIFF
--- a/nvd3/ipynb.py
+++ b/nvd3/ipynb.py
@@ -12,7 +12,7 @@ try:
     _ip = get_ipython()
 except:
     _ip = None
-if _ip and _ip.__module__.startswith('IPython'):
+if _ip and _ip.__module__.lower().startswith('ipy'):
     global _js_initialized
     _js_initialized = False
 


### PR DESCRIPTION
In Jupyter, the _ip.__module__ is 'ipykernel.zmqshell', which did not start with 'iPython'.  This prevented the remaining code from running.