### PR TITLE
Fix custom graphs attributes starting with "."

### DIFF
--- a/nvd3/templates/content.html
+++ b/nvd3/templates/content.html
@@ -76,7 +76,7 @@
     {% block custoattr %}
         {# add custom chart attributes #}
         {% for attr, value in chart.chart_attr.items() %}
-            {% if value is string and value.startswith(".") %}:
+            {% if value is string and value.startswith(".") %}
                 chart.{{ attr }}{{ value }};
             {% else %}
                 chart.{{ attr }}({{ value }});


### PR DESCRIPTION
When rendering custom chart attributes starting with ".", the content template renders unwanted colons, and breaks the javascript syntax. This patch removes the extra colons.