### PR TITLE
fix x_axis dates in linechart examples

### DIFF
--- a/nvd3/cumulativeLineChart.py
+++ b/nvd3/cumulativeLineChart.py
@@ -21,7 +21,7 @@ class cumulativeLineChart(TemplateMixin, NVD3Chart):
 
         from nvd3 import cumulativeLineChart
         chart = cumulativeLineChart(name='cumulativeLineChart', x_is_date=True)
-        xdata = [1365026400000000, 1365026500000000, 1365026600000000]
+        xdata = [1365026400000, 1365026500000, 1365026600000]
         ydata = [6, 5, 1]
         y2data = [36, 55, 11]
 
@@ -38,13 +38,13 @@ class cumulativeLineChart(TemplateMixin, NVD3Chart):
 
         <div id="cumulativeLineChart"><svg style="height:450px; width:100%"></svg></div>
         <script>
-            data_cumulativeLineChart=[{"values": [{"y": 6, "x": 1365026400000000},
-            {"y": 5, "x": 1365026500000000},
-            {"y": 1, "x": 1365026600000000}],
+            data_cumulativeLineChart=[{"values": [{"y": 6, "x": 1365026400000},
+            {"y": 5, "x": 1365026500000},
+            {"y": 1, "x": 1365026600000}],
             "key": "Serie 1", "yAxis": "1"},
-            {"values": [{"y": 36, "x": 1365026400000000},
-            {"y": 55, "x": 1365026500000000},
-            {"y": 11, "x": 1365026600000000}], "key": "Serie 2", "yAxis": "1"}];
+            {"values": [{"y": 36, "x": 1365026400000},
+            {"y": 55, "x": 1365026500000},
+            {"y": 11, "x": 1365026600000}], "key": "Serie 2", "yAxis": "1"}];
             nv.addGraph(function() {
                 var chart = nv.models.cumulativeLineChart();
                 chart.margin({top: 30, right: 60, bottom: 20, left: 60});

--- a/nvd3/lineWithFocusChart.py
+++ b/nvd3/lineWithFocusChart.py
@@ -23,7 +23,7 @@ class lineWithFocusChart(TemplateMixin, NVD3Chart):
 
         from nvd3 import lineWithFocusChart
         chart = lineWithFocusChart(name='lineWithFocusChart', x_is_date=True, x_axis_format="%d %b %Y")
-        xdata = [1365026400000000, 1365026500000000, 1365026600000000, 1365026700000000, 1365026800000000, 1365026900000000, 1365027000000000]
+        xdata = [1365026400000, 1365026500000, 1365026600000, 1365026700000, 1365026800000, 1365026900000, 1365027000000]
         ydata = [-6, 5, -1, 2, 4, 8, 10]
 
         extra_serie = {"tooltip": {"y_start": "", "y_end": " ext"},
@@ -37,7 +37,7 @@ class lineWithFocusChart(TemplateMixin, NVD3Chart):
 
         <div id="lineWithFocusChart"><svg style="height:450px; width:100%"></svg></div>
         <script>
-            data_lineWithFocusChart=[{"values": [{"y": -6, "x": 1365026400000000}, {"y": 5, "x": 1365026500000000}, {"y": -1, "x": 1365026600000000}], "key": "Serie 1", "yAxis": "1"}];
+            data_lineWithFocusChart=[{"values": [{"y": -6, "x": 1365026400000}, {"y": 5, "x": 1365026500000}, {"y": -1, "x": 1365026600000}], "key": "Serie 1", "yAxis": "1"}];
             nv.addGraph(function() {
                 var chart = nv.models.lineWithFocusChart();
                 chart.margin({top: 30, right: 60, bottom: 20, left: 60});


### PR DESCRIPTION
[cumulativeLineChart](https://python-nvd3.readthedocs.org/en/latest/classes-doc/cumulative-line-chart.html) and [lineWithFocusChart](https://python-nvd3.readthedocs.org/en/latest/classes-doc/line-with-focus-chart.html) have example dates in 5225, not 2013

before:
![before](https://cloud.githubusercontent.com/assets/1437341/13201962/056e335c-d888-11e5-9938-221f2422f842.png)

after:
![after](https://cloud.githubusercontent.com/assets/1437341/13201963/0a2a6410-d888-11e5-966a-0e15a1483374.png)