### PR TITLE
Add candlestick chart type

### DIFF
--- a/examples/demo_all.py
+++ b/examples/demo_all.py
@@ -281,9 +281,9 @@ chart.set_containerheader("\n\n<h2>" + type + "</h2>\n\n")
 nb_element = 100
 start_time = int(time.mktime(datetime.datetime(2012, 6, 1).timetuple()) * 1000)
 xdata = range(nb_element)
-xdata = map(lambda x: start_time + x * 1000000000, xdata)
+xdata = list(map(lambda x: start_time + x * 1000000000, xdata))
 ydata = [i + random.randint(1, 10) for i in range(nb_element)]
-ydata2 = map(lambda x: x * 2, ydata)
+ydata2 = list(map(lambda x: x * 2, ydata))
 
 tooltip_date = "%d %b %Y %H:%M:%S %p"
 extra_serie = {"tooltip": {"y_start": "There are ", "y_end": " calls"},

--- a/nvd3/NVD3Chart.py
+++ b/nvd3/NVD3Chart.py
@@ -162,7 +162,7 @@ class NVD3Chart(object):
         self.header_css = [
             '<link href="%s" rel="stylesheet" />' % h for h in
             (
-                'https://cdnjs.cloudflare.com/ajax/libs/nvd3/1.7.1/nv.d3.min.css' if self.remote_js_assets else self.assets_directory + 'nvd3/src/nv.d3.css',
+                'https://cdnjs.cloudflare.com/ajax/libs/nvd3/1.8.2/nv.d3.min.css' if self.remote_js_assets else self.assets_directory + 'nvd3/src/nv.d3.css',
             )
         ]
 
@@ -170,7 +170,7 @@ class NVD3Chart(object):
             '<script src="%s"></script>' % h for h in
             (
                 'https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js' if self.remote_js_assets else self.assets_directory + 'd3/d3.min.js',
-                'https://cdnjs.cloudflare.com/ajax/libs/nvd3/1.7.1/nv.d3.min.js' if self.remote_js_assets else self.assets_directory + 'nvd3/nv.d3.min.js'
+                'https://cdnjs.cloudflare.com/ajax/libs/nvd3/1.8.2/nv.d3.min.js' if self.remote_js_assets else self.assets_directory + 'nvd3/nv.d3.min.js'
             )
         ]
 

--- a/nvd3/__init__.py
+++ b/nvd3/__init__.py
@@ -13,7 +13,8 @@ __version__ = '0.14.2'
 __all__ = ['lineChart', 'pieChart', 'lineWithFocusChart',
            'stackedAreaChart', 'multiBarHorizontalChart',
            'linePlusBarChart', 'cumulativeLineChart',
-           'scatterChart', 'discreteBarChart', 'multiBarChart']
+           'scatterChart', 'discreteBarChart', 'multiBarChart',
+           'bulletChart', 'candlestickBarChart']
 
 
 from .lineChart import lineChart
@@ -27,4 +28,5 @@ from .scatterChart import scatterChart
 from .discreteBarChart import discreteBarChart
 from .multiBarChart import multiBarChart
 from .bulletChart import bulletChart
+from .candlestickBar import candlestickBarChart
 from . import ipynb

--- a/nvd3/candlestickBar.py
+++ b/nvd3/candlestickBar.py
@@ -1,0 +1,118 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""
+Python-nvd3 is a Python wrapper for NVD3 graph library.
+NVD3 is an attempt to build re-usable charts and chart components
+for d3.js without taking away the power that d3.js gives you.
+
+Project location : https://github.com/areski/python-nvd3
+"""
+
+from .NVD3Chart import NVD3Chart, TemplateMixin
+
+
+class candlestickBarChart(TemplateMixin, NVD3Chart):
+    """
+    A candlestick bar chart is a chart used in finance to demonstrate
+    the movements of an asset or currency. It shows the opening,
+    closing, high, and low values for each data point.
+
+    Python example::
+
+
+    values = [
+        {"date": 15854, "open": 165.42, "high": 165.8, "low": 164.34, "close": 165.22, "volume": 160363400, "adjusted": 164.35},
+        {"date": 15855, "open": 165.35, "high": 166.59, "low": 165.22, "close": 165.83, "volume": 107793800, "adjusted": 164.96},
+        {"date": 15856, "open": 165.37, "high": 166.31, "low": 163.13, "close": 163.45, "volume": 176850100, "adjusted": 162.59},
+        {"date": 15859, "open": 163.83, "high": 164.46, "low": 162.66, "close": 164.35, "volume": 168390700, "adjusted": 163.48},
+        {"date": 15860, "open": 164.44, "high": 165.1, "low": 162.73, "close": 163.56, "volume": 157631500, "adjusted": 162.7},
+        {"date": 15861, "open": 163.09, "high": 163.42, "low": 161.13, "close": 161.27, "volume": 211737800, "adjusted": 160.42},
+        ]
+
+        from nvd3 import candlestickBarChart
+        type = 'candlestickBarChart'
+        chart = candlestickBarChart(name=type, height=600, width=1400)
+        chart.add_serie(values=values)
+        chart.buildhtml()
+
+    Javascript generated:
+
+    .. raw:: html
+
+    <!DOCTYPE html>
+    <html lang="en">
+        <head>
+            <meta charset="utf-8" />
+            <link href="https://cdnjs.cloudflare.com/ajax/libs/nvd3/1.8.2/nv.d3.min.css" rel="stylesheet" />
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/nvd3/1.8.2/nv.d3.min.js"></script>
+        </head>
+        <body>
+
+        <div id="candlestickbarchart"><svg style="width:1400px;height:600px;"></svg></div>
+
+
+        <script>
+
+
+
+                data_candlestickbarchart=[{"values": [{"adjusted": 164.35, "close": 165.22, "open": 165.42, "high": 165.8, "date": "2015-01-01", "low": 164.34, "volume": 160363400}, {"adjusted": 164.96, "close": 165.83, "open": 165.35, "high": 166.59, "date": "2015-01-02", "low": 165.22, "volume": 107793800}, {"adjusted": 162.59, "close": 163.45, "open": 165.37, "high": 166.31, "date": "2015-01-03", "low": 163.13, "volume": 176850100}, {"adjusted": 163.48, "close": 164.35, "open": 163.83, "high": 164.46, "date": "2015-01-04", "low": 162.66, "volume": 168390700}, {"adjusted": 162.7, "close": 163.56, "open": 164.44, "high": 165.1, "date": "2015-01-05", "low": 162.73, "volume": 157631500}, {"adjusted": 160.42, "close": 161.27, "open": 163.09, "high": 163.42, "date": "2015-01-06", "low": 161.13, "volume": 211737800}], "key": "Serie 1"}];
+
+
+
+            var parseDate = d3.time.format('%Y-%m-%d').parse;
+
+
+            nv.addGraph(function() {
+            var chart = nv.models.candlestickBarChart()
+                .x(function(d) { return parseDate(d['date']); })
+                .y(function(d) { return d['close'] })
+                .duration(250)
+                .margin({left: 75, bottom: 50});
+
+            chart.xAxis
+                    .axisLabel("Dates")
+                    .tickFormat(function(d) {
+                        return d3.time.format('%Y-%m-%d')(new Date(d));
+                    });
+            chart.yAxis
+                    .axisLabel('Stock Price')
+                    .tickFormat(function(d,i){ return '$' + d3.format(',.1f')(d); });
+            d3.select("#candlestickbarchart svg")
+                    .datum(data_candlestickbarchart)
+                    .transition().duration(500)
+                    .call(chart);
+            nv.utils.windowResize(chart.update);
+            return chart;
+        });
+
+        </script>
+
+        </body>
+    </html>
+
+    """
+
+    CHART_FILENAME = "./candlestickbar.html"
+    template_chart_nvd3 = NVD3Chart.template_environment.get_template(
+        CHART_FILENAME)
+
+    def __init__(self, **kwargs):
+        super(candlestickBarChart, self).__init__(**kwargs)
+        self.model = 'candlestickBarChart'
+
+        height = kwargs.get('height', 450)
+        width = kwargs.get('width', None)
+
+        self.set_graph_height(height)
+        if width:
+            self.set_graph_width(width)
+
+    def add_serie(self, values, name=None, **kwargs):
+        if not name:
+            name = "Serie %d" % (self.serie_no)
+        data_keyvalue = {'values': values, 'key': name}
+
+        self.serie_no += 1
+        self.series.append(data_keyvalue)

--- a/nvd3/templates/candlestickbar.html
+++ b/nvd3/templates/candlestickbar.html
@@ -1,0 +1,38 @@
+{# This template adds attributes unique
+    to candlestickChart #}
+
+{% extends 'content.html' %}
+
+{% block body %}
+
+    {% block data %}
+    {{ super () }}
+    {% endblock data %}
+
+
+        var parseDate = d3.time.format('%Y-%m-%d').parse;
+
+
+        nv.addGraph(function() {
+        var chart = nv.models.candlestickBarChart()
+            .x(function(d) { return parseDate(d['date']); })
+            .y(function(d) { return d['close'] })
+            .duration(250)
+            .margin({left: 75, bottom: 50});
+
+        chart.xAxis
+                .axisLabel("Dates")
+                .tickFormat(function(d) {
+                    return d3.time.format('%Y-%m-%d')(new Date(d));
+                });
+        chart.yAxis
+                .axisLabel('Stock Price')
+                .tickFormat(function(d,i){ return '$' + d3.format(',.1f')(d); });
+        d3.select("#{{ chart.name }} svg")
+                .datum(data_{{ chart.name }})
+                .transition().duration(500)
+                .call(chart);
+        nv.utils.windowResize(chart.update);
+        return chart;
+    });
+{% endblock body %}

--- a/tests.py
+++ b/tests.py
@@ -12,6 +12,7 @@ from nvd3 import discreteBarChart
 from nvd3 import pieChart
 from nvd3 import multiBarChart
 from nvd3 import bulletChart
+from nvd3 import candlestickBarChart
 from nvd3.NVD3Chart import stab
 from nvd3.translator import Function, AnonymousFunction, Assignment
 import random
@@ -71,10 +72,23 @@ class ChartTest(unittest.TestCase):
         kwargs1 = {'color': 'green'}
         kwargs2 = {'color': 'red'}
 
-        extra_serie = {"tooltip": {"y_start": "There is ", "y_end": " random values"}}
-        chart.add_serie(name="Random X-Axis", y=ydata, x=xdata, extra=extra_serie, **kwargs1)
+        extra_serie = {
+            "tooltip": {
+                "y_start": "There is ",
+                "y_end": " random values"}}
+        chart.add_serie(
+            name="Random X-Axis",
+            y=ydata,
+            x=xdata,
+            extra=extra_serie,
+            **kwargs1)
         extra_serie = {"tooltip": {"y_start": "", "y_end": " double values"}}
-        chart.add_serie(name="Double X-Axis", y=ydata2, x=xdata, extra=extra_serie, **kwargs2)
+        chart.add_serie(
+            name="Double X-Axis",
+            y=ydata2,
+            x=xdata,
+            extra=extra_serie,
+            **kwargs2)
 
         chart.buildhtml()
 
@@ -82,12 +96,24 @@ class ChartTest(unittest.TestCase):
         """Test line Plus Bar Chart"""
         type = "linePlusBarChart"
         chart = linePlusBarChart(name=type, date=True, height=350)
-        start_time = int(time.mktime(datetime.datetime(2012, 6, 1).timetuple()) * 1000)
+        start_time = int(
+            time.mktime(
+                datetime.datetime(
+                    2012,
+                    6,
+                    1).timetuple()) *
+            1000)
         nb_element = 100
         xdata = list(range(nb_element))
         xdata = [start_time + x * 1000000000 for x in xdata]
         ydata = [i + random.randint(1, 10) for i in range(nb_element)]
-        ydata2 = [i + random.randint(1, 10) for i in reversed(list(range(nb_element)))]
+        ydata2 = [
+            i +
+            random.randint(
+                1,
+                10) for i in reversed(
+                list(
+                    range(nb_element)))]
         kwargs = {}
         kwargs['bar'] = True
         chart.add_serie(y=ydata, x=xdata, **kwargs)
@@ -134,7 +160,13 @@ class ChartTest(unittest.TestCase):
         """Test Cumulative Line Chart"""
         type = "cumulativeLineChart"
         chart = cumulativeLineChart(name=type, height=400)
-        start_time = int(time.mktime(datetime.datetime(2012, 6, 1).timetuple()) * 1000)
+        start_time = int(
+            time.mktime(
+                datetime.datetime(
+                    2012,
+                    6,
+                    1).timetuple()) *
+            1000)
         nb_element = 100
         xdata = list(range(nb_element))
         xdata = [start_time + x * 1000000000 for x in xdata]
@@ -178,10 +210,32 @@ class ChartTest(unittest.TestCase):
     def test_pieChart(self):
         """Test Pie Chart"""
         type = "pieChart"
-        chart = pieChart(name=type, color_category='category20c', height=400, width=400)
-        xdata = ["Orange", "Banana", "Pear", "Kiwi", "Apple", "Strawberry", "Pineapple"]
-        color_list = ['orange', 'yellow', '#C5E946', '#95b43f', 'red', '#FF2259', '#F6A641']
-        extra_serie = {"tooltip": {"y_start": "", "y_end": " cal"}, "color_list": color_list}
+        chart = pieChart(
+            name=type,
+            color_category='category20c',
+            height=400,
+            width=400)
+        xdata = [
+            "Orange",
+            "Banana",
+            "Pear",
+            "Kiwi",
+            "Apple",
+            "Strawberry",
+            "Pineapple"]
+        color_list = [
+            'orange',
+            'yellow',
+            '#C5E946',
+            '#95b43f',
+            'red',
+            '#FF2259',
+            '#F6A641']
+        extra_serie = {
+            "tooltip": {
+                "y_start": "",
+                "y_end": " cal"},
+            "color_list": color_list}
         ydata = [3, 4, 0, 1, 5, 7, 3]
         chart.add_serie(y=ydata, x=xdata, extra=extra_serie)
         chart.buildhtml()
@@ -189,8 +243,20 @@ class ChartTest(unittest.TestCase):
     def test_donutPieChart(self):
         """Test Donut Pie Chart"""
         type = "pieChart"
-        chart = pieChart(name=type, height=400, width=400, donut=True, donutRatio=0.2)
-        xdata = ["Orange", "Banana", "Pear", "Kiwi", "Apple", "Strawberry", "Pineapple"]
+        chart = pieChart(
+            name=type,
+            height=400,
+            width=400,
+            donut=True,
+            donutRatio=0.2)
+        xdata = [
+            "Orange",
+            "Banana",
+            "Pear",
+            "Kiwi",
+            "Apple",
+            "Strawberry",
+            "Pineapple"]
         ydata = [3, 4, 0, 1, 5, 7, 3]
         chart.add_serie(y=ydata, x=xdata)
         chart.buildhtml()
@@ -227,7 +293,7 @@ class ChartTest(unittest.TestCase):
             markers=markers)
         chart.buildhtml()
         assert 'data_bulletchart' in chart.htmlcontent
-        assert '"title": ["Revenue"]'  in chart.htmlcontent
+        assert '"title": ["Revenue"]' in chart.htmlcontent
         assert '"ranges": [100, 250, 300]' in chart.htmlcontent
         assert 'nv.models.bulletChart();' in chart.htmlcontent
 
@@ -243,10 +309,196 @@ class ChartTest(unittest.TestCase):
             subtitle=subtitle,
             ranges=ranges,
             measures=measures
-            )
+        )
         chart.buildhtml()
         assert 'data_bulletchart' in chart.htmlcontent
         assert 'marker' not in chart.htmlcontent
+
+
+class CandleStickBarChartTest(unittest.TestCase):
+
+    values = [
+        {"date": '2015-01-01', "open": 165.42, "high": 165.8, "low": 164.34,
+            "close": 165.22, "volume": 160363400, "adjusted": 164.35},
+        {"date": '2015-01-02', "open": 165.35, "high": 166.59, "low": 165.22,
+            "close": 165.83, "volume": 107793800, "adjusted": 164.96},
+        {"date": '2015-01-03', "open": 165.37, "high": 166.31, "low": 163.13,
+            "close": 163.45, "volume": 176850100, "adjusted": 162.59},
+        {"date": '2015-01-04', "open": 163.83, "high": 164.46, "low": 162.66,
+            "close": 164.35, "volume": 168390700, "adjusted": 163.48},
+        {"date": '2015-01-05', "open": 164.44, "high": 165.1, "low": 162.73,
+            "close": 163.56, "volume": 157631500, "adjusted": 162.7},
+        {"date": '2015-01-06', "open": 163.09, "high": 163.42, "low": 161.13,
+            "close": 161.27, "volume": 211737800, "adjusted": 160.42},
+        {"date": '2015-01-07', "open": 161.2, "high": 162.74, "low": 160.25,
+            "close": 162.73, "volume": 200225500, "adjusted": 161.87},
+        {"date": '2015-01-08', "open": 163.85, "high": 164.95, "low": 163.14,
+            "close": 164.8, "volume": 188337800, "adjusted": 163.93},
+        {"date": '2015-01-09', "open": 165.31, "high": 165.4, "low": 164.37,
+            "close": 164.8, "volume": 105667100, "adjusted": 163.93},
+        {"date": '2015-01-10', "open": 163.3, "high": 164.54, "low": 162.74,
+            "close": 163.1, "volume": 159505400, "adjusted": 162.24},
+        {"date": '2015-01-11', "open": 164.22, "high": 164.39, "low": 161.6,
+            "close": 161.75, "volume": 177361500, "adjusted": 160.9},
+        {"date": '2015-01-12', "open": 161.66, "high": 164.5, "low": 161.3,
+            "close": 164.21, "volume": 163587800, "adjusted": 163.35},
+        {"date": '2015-01-13', "open": 164.03, "high": 164.67, "low": 162.91,
+            "close": 163.18, "volume": 141197500, "adjusted": 162.32},
+        {"date": '2015-01-14', "open": 164.29, "high": 165.22, "low": 163.22,
+            "close": 164.44, "volume": 136295600, "adjusted": 163.57},
+        {"date": '2015-01-15', "open": 164.53, "high": 165.99, "low": 164.52,
+            "close": 165.74, "volume": 114695600, "adjusted": 164.87},
+        {"date": '2015-01-16', "open": 165.6, "high": 165.89, "low": 163.38,
+            "close": 163.45, "volume": 206149500, "adjusted": 162.59},
+        {"date": '2015-01-17', "open": 161.86, "high": 163.47, "low": 158.98,
+            "close": 159.4, "volume": 321255900, "adjusted": 158.56},
+        {"date": '2015-01-18', "open": 159.64, "high": 159.76, "low": 157.47,
+            "close": 159.07, "volume": 271956800, "adjusted": 159.07},
+        {"date": '2015-01-19', "open": 157.41, "high": 158.43, "low": 155.73,
+            "close": 157.06, "volume": 222329000, "adjusted": 157.06},
+        {"date": '2015-01-20', "open": 158.48, "high": 160.1, "low": 157.42,
+            "close": 158.57, "volume": 162262200, "adjusted": 158.57},
+        {"date": '2015-01-21', "open": 159.87, "high": 160.5, "low": 159.25,
+            "close": 160.14, "volume": 134848000, "adjusted": 160.14},
+        {"date": '2015-01-22', "open": 161.1, "high": 161.82, "low": 160.95,
+            "close": 161.08, "volume": 129483700, "adjusted": 161.08},
+        {"date": '2015-01-23', "open": 160.63, "high": 161.4, "low": 159.86,
+            "close": 160.42, "volume": 160402900, "adjusted": 160.42},
+        {"date": '2015-01-24', "open": 161.26, "high": 162.48, "low": 161.08,
+            "close": 161.36, "volume": 131954800, "adjusted": 161.36},
+        {"date": '2015-01-25', "open": 161.12, "high": 162.3, "low": 160.5,
+            "close": 161.21, "volume": 154863700, "adjusted": 161.21},
+        {"date": '2015-01-26', "open": 160.48, "high": 161.77, "low": 160.22,
+            "close": 161.28, "volume": 75216400, "adjusted": 161.28},
+        {"date": '2015-01-27', "open": 162.47, "high": 163.08, "low": 161.3,
+            "close": 163.02, "volume": 122416900, "adjusted": 163.02},
+        {"date": '2015-01-28', "open": 163.86, "high": 164.39, "low": 163.08,
+            "close": 163.95, "volume": 108092500, "adjusted": 163.95},
+        {"date": '2015-01-29', "open": 164.98, "high": 165.33, "low": 164.27,
+            "close": 165.13, "volume": 119298000, "adjusted": 165.13},
+        {"date": '2015-01-30', "open": 164.97, "high": 165.75, "low": 164.63,
+            "close": 165.19, "volume": 121410100, "adjusted": 165.19},
+        {"date": '2015-01-31', "open": 167.11, "high": 167.61, "low": 165.18,
+            "close": 167.44, "volume": 135592200, "adjusted": 167.44},
+        {"date": '2015-02-01', "open": 167.39, "high": 167.93, "low": 167.13,
+            "close": 167.51, "volume": 104212700, "adjusted": 167.51},
+        {"date": '2015-02-02', "open": 167.97, "high": 168.39, "low": 167.68,
+            "close": 168.15, "volume": 69450600, "adjusted": 168.15},
+        {"date": '2015-02-03', "open": 168.26, "high": 168.36, "low": 167.07,
+            "close": 167.52, "volume": 88702100, "adjusted": 167.52},
+        {"date": '2015-02-04', "open": 168.16, "high": 168.48, "low": 167.73,
+            "close": 167.95, "volume": 92873900, "adjusted": 167.95},
+        {"date": '2015-02-05', "open": 168.31, "high": 169.27, "low": 168.2,
+            "close": 168.87, "volume": 103620100, "adjusted": 168.87},
+        {"date": '2015-02-06', "open": 168.52, "high": 169.23, "low": 168.31,
+            "close": 169.17, "volume": 103831700, "adjusted": 169.17},
+        {"date": '2015-02-07', "open": 169.41, "high": 169.74, "low": 169.01,
+            "close": 169.5, "volume": 79428600, "adjusted": 169.5},
+        {"date": '2015-02-08', "open": 169.8, "high": 169.83, "low": 169.05,
+            "close": 169.14, "volume": 80829700, "adjusted": 169.14},
+        {"date": '2015-02-09', "open": 169.79, "high": 169.86, "low": 168.18,
+            "close": 168.52, "volume": 112914000, "adjusted": 168.52},
+        {"date": '2015-02-10', "open": 168.22, "high": 169.08, "low": 167.94,
+            "close": 168.93, "volume": 111088600, "adjusted": 168.93},
+        {"date": '2015-02-11', "open": 168.22, "high": 169.16, "low": 167.52,
+            "close": 169.11, "volume": 107814600, "adjusted": 169.11},
+        {"date": '2015-02-12', "open": 168.68, "high": 169.06, "low": 168.11,
+            "close": 168.59, "volume": 79695000, "adjusted": 168.59},
+        {"date": '2015-02-13', "open": 169.1, "high": 169.28, "low": 168.19,
+            "close": 168.59, "volume": 85209600, "adjusted": 168.59},
+        {"date": '2015-02-14', "open": 168.94, "high": 169.85, "low": 168.49,
+            "close": 168.71, "volume": 142388700, "adjusted": 168.71},
+        {"date": '2015-02-15', "open": 169.99, "high": 170.81, "low": 169.9,
+            "close": 170.66, "volume": 110438400, "adjusted": 170.66},
+        {"date": '2015-02-16', "open": 170.28, "high": 170.97, "low": 170.05,
+            "close": 170.95, "volume": 91116700, "adjusted": 170.95},
+        {"date": '2015-02-17', "open": 170.57, "high": 170.96, "low": 170.35,
+            "close": 170.7, "volume": 54072700, "adjusted": 170.7},
+        {"date": '2015-02-18', "open": 170.37, "high": 170.74, "low": 169.35,
+            "close": 169.73, "volume": 87495000, "adjusted": 169.73},
+        {"date": '2015-02-19', "open": 169.19, "high": 169.43, "low": 168.55,
+            "close": 169.18, "volume": 84854700, "adjusted": 169.18},
+        {"date": '2015-02-20', "open": 169.98, "high": 170.18, "low": 168.93,
+            "close": 169.8, "volume": 102181300, "adjusted": 169.8},
+        {"date": '2015-02-21', "open": 169.58, "high": 170.1, "low": 168.72,
+            "close": 169.31, "volume": 91757700, "adjusted": 169.31},
+        {"date": '2015-02-22', "open": 168.46, "high": 169.31, "low": 168.38,
+            "close": 169.11, "volume": 68593300, "adjusted": 169.11},
+        {"date": '2015-02-23', "open": 169.41, "high": 169.9, "low": 168.41,
+            "close": 169.61, "volume": 80806000, "adjusted": 169.61},
+        {"date": '2015-02-24', "open": 169.53, "high": 169.8, "low": 168.7,
+            "close": 168.74, "volume": 79829200, "adjusted": 168.74},
+        {"date": '2015-02-25', "open": 167.41, "high": 167.43, "low": 166.09,
+            "close": 166.38, "volume": 152931800, "adjusted": 166.38},
+        {"date": '2015-02-26', "open": 166.06, "high": 166.63, "low": 165.5,
+            "close": 165.83, "volume": 130868200, "adjusted": 165.83},
+        {"date": '2015-02-27', "open": 165.64, "high": 166.21, "low": 164.76,
+            "close": 164.77, "volume": 96437600, "adjusted": 164.77},
+        {"date": '2015-02-28', "open": 165.04, "high": 166.2, "low": 164.86,
+            "close": 165.58, "volume": 89294400, "adjusted": 165.58},
+        {"date": '2015-02-29', "open": 165.12, "high": 166.03, "low": 164.19,
+            "close": 164.56, "volume": 159530500, "adjusted": 164.56},
+        {"date": '2015-03-01', "open": 164.9, "high": 166.3, "low": 164.89,
+            "close": 166.06, "volume": 101471400, "adjusted": 166.06},
+        {"date": '2015-03-02', "open": 166.55, "high": 166.83, "low": 165.77,
+            "close": 166.62, "volume": 90888900, "adjusted": 166.62},
+        {"date": '2015-03-03', "open": 166.79, "high": 167.3, "low": 165.89,
+            "close": 166, "volume": 89702100, "adjusted": 166},
+        {"date": '2015-03-04', "open": 164.36, "high": 166, "low": 163.21,
+            "close": 163.33, "volume": 158619400, "adjusted": 163.33},
+        {"date": '2015-03-05', "open": 163.26, "high": 164.49, "low": 163.05,
+            "close": 163.91, "volume": 108113000, "adjusted": 163.91},
+        {"date": '2015-03-06', "open": 163.55, "high": 165.04, "low": 163.4,
+            "close": 164.17, "volume": 119200500, "adjusted": 164.17},
+        {"date": '2015-03-07', "open": 164.51, "high": 164.53, "low": 163.17,
+            "close": 163.65, "volume": 134560800, "adjusted": 163.65},
+        {"date": '2015-03-08', "open": 165.23, "high": 165.58, "low": 163.7,
+            "close": 164.39, "volume": 142322300, "adjusted": 164.39},
+        {"date": '2015-03-09', "open": 164.43, "high": 166.03, "low": 164.13,
+            "close": 165.75, "volume": 97304000, "adjusted": 165.75},
+        {"date": '2015-03-10', "open": 165.85, "high": 166.4, "low": 165.73,
+            "close": 165.96, "volume": 62930500, "adjusted": 165.96}
+    ]
+
+    def test_can_make_candlestickChart(self):
+        type = 'candlestickChart'
+        chart = candlestickBarChart(name=type, height=600, width=1400)
+        chart.add_serie(values=self.__class__.values)
+        chart.buildhtml()
+
+    def test_candlestickBarChart_htmlcontent_correct(self):
+        type = 'candlestickBarChart'
+        chart = candlestickBarChart(name=type, height=600, width=1400)
+        chart.add_serie(values=self.__class__.values)
+        chart.buildhtml()
+
+        assert 'data_candlestickbarchart' in chart.htmlcontent
+        assert 'nv.models.candlestickBarChart()' in chart.htmlcontent
+        # binds x data and y data
+        assert ".x(function(d) { return parseDate(d['date']); })" in \
+            chart.htmlcontent
+        assert ".y(function(d) { return d['close'] })" in \
+            chart.htmlcontent
+
+    def test_can_change_chart_type(self):
+        type = 'someCandlestickChart'
+        chart = candlestickBarChart(name=type, height=600, width=1400)
+        chart.add_serie(values=self.__class__.values)
+        chart.buildhtml()
+
+        assert '<div id="somecandlestickchart">' in chart.htmlcontent
+        assert 'data_somecandlestickchart' in chart.htmlcontent
+
+        # And if we change the chart's type, it still works
+        type = 'candleStickChart'
+        chart = candlestickBarChart(name=type, height=600, width=1400)
+        chart.add_serie(values=self.__class__.values)
+        chart.buildhtml()
+
+        assert '<div id="candlestickchart">' in chart.htmlcontent
+        assert 'data_candlestickchart' in chart.htmlcontent
+
+
 
 
 class FuncTest(unittest.TestCase):
@@ -265,7 +517,7 @@ class TranslatorTest(unittest.TestCase):
                     AnonymousFunction('d', 'return d.label;')
                 ).y(AnonymousFunction('d', 'return d.value;')
                     ).showLabels('true')
-                )
+            )
             )
         )
         self.assertEqual(str(func),


### PR DESCRIPTION
Added ability to create candlestick Chart, like this example here: https://github.com/novus/nvd3/blob/master/examples/candlestickChart.html .

Since this was not in NVD3 version 1.7.1, also went ahead and upgraded to 1.8.2.

Added accompanying tests as well, tested with the same data set that the NVD3 sample candlestick chart uses. 
