### PR TITLE
make tooltip separator configurable

### DIFF
--- a/nvd3/NVD3Chart.py
+++ b/nvd3/NVD3Chart.py
@@ -129,6 +129,7 @@ class NVD3Chart(object):
         self.show_controls = kwargs.get('show_controls', True)
         self.show_legend = kwargs.get('show_legend', True)
         self.show_labels = kwargs.get('show_labels', True)
+        self.tooltip_separator = kwargs.get('tooltip_separator')
         self.tag_script_js = kwargs.get('tag_script_js', True)
         self.use_interactive_guideline = kwargs.get("use_interactive_guideline",
                                                     False)

--- a/nvd3/templates/content.html
+++ b/nvd3/templates/content.html
@@ -56,7 +56,7 @@
                         var x = String(graph.point.x);
                         var y = String(graph.point.y);
                         {{ chart.tooltip_condition_string }}
-                        tooltip_str = '<center><b>'+key+'</b></center>' + y + ' at ' + x;
+                        tooltip_str = '<center><b>'+key+'</b></center>' + y + ' {{ chart.tooltip_separator|default('at', True) }} ' + x;
                         return tooltip_str;
                     });
                 {% endif %}
@@ -65,7 +65,7 @@
                     var x = d3.time.format("{{ chart.charttooltip_dateformat }}")(new Date(parseInt(graph.point.x)));
                     var y = String(graph.point.y);
                     {{ chart.tooltip_condition_string }}
-                    tooltip_str = '<center><b>'+key+'</b></center>' + y + ' on ' + x;
+                    tooltip_str = '<center><b>'+key+'</b></center>' + y + ' {{ chart.tooltip_separator|default('on', True) }} ' + x;
                     return tooltip_str;
                 });
             {% endif %}


### PR DESCRIPTION
so 'at' is not hardcoded in the tooltip

![before](https://cloud.githubusercontent.com/assets/1437341/21157338/3a00408a-c179-11e6-8489-878d9b84d4f4.png)
![after2](https://cloud.githubusercontent.com/assets/1437341/21157337/39ffe04a-c179-11e6-9bbd-dfe195ba0706.png)
![after1](https://cloud.githubusercontent.com/assets/1437341/21157339/3a014192-c179-11e6-926d-5bbf61202f44.png)
