### PR TITLE
Do not initialize show_controls twice; keeps second initialization since it is one applied

### DIFF
--- a/nvd3/NVD3Chart.py
+++ b/nvd3/NVD3Chart.py
@@ -72,7 +72,6 @@ class NVD3Chart(object):
         :keyword: **height** - default - ``''``
         :keyword: **width** - default - ``''``
         :keyword: **stacked** - default - ``False``
-        :keyword: **show_controls** - default - ``None``
         :keyword: **focus_enable** - default - ``False``
         :keyword: **resize** - define - ``False``
         :keyword: **xAxis_rotateLabel** - default - ``0``
@@ -125,7 +124,6 @@ class NVD3Chart(object):
         self.height = kwargs.get('height', '')
         self.width = kwargs.get('width', '')
         self.stacked = kwargs.get('stacked', False)
-        self.show_controls = kwargs.get('show_controls', None)
         self.focus_enable = kwargs.get('focus_enable', False)
         self.resize = kwargs.get('resize', False)
         self.xAxis_rotateLabel = kwargs.get('xAxis_rotateLabel', 0)


### PR DESCRIPTION
Non-urgent clean up of something I noticed. If you inspect nvd3\NVD3Chart.py you'll see show_controls is documented twice (lines 75 and 80) and initialized twice (lines 128 and 133). This just cleans it up to document and initialize only once. I went with the second docstring / init since that's what is being applied right now.