### PR TITLE
Fix error in multiBarChart_date example by casting map to list

### DIFF
--- a/examples/multiBarChart_date.py
+++ b/examples/multiBarChart_date.py
@@ -25,7 +25,7 @@ chart.set_containerheader("\n\n<h2>" + type + "</h2>\n\n")
 nb_element = 100
 start_time = int(time.mktime(datetime.datetime(2013, 6, 1).timetuple()) * 1000)
 xdata = range(nb_element)
-xdata = map(lambda x: start_time + x * 100000000, xdata)
+xdata = list(map(lambda x: start_time + x * 100000000, xdata))
 ydata = [i + random.randint(1, 10) for i in range(nb_element)]
 ydata2 = map(lambda x: x * 2, ydata)
 


### PR DESCRIPTION
Previously demo chart would not render due to this error:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\CQL\Repos\python-nvd3\nvd3\NVD3Chart.py", line 241, in add_serie
    serie = [{'x': x[i], 'y': y} for i, y in enumerate(y)]
  File "C:\Users\CQL\Repos\python-nvd3\nvd3\NVD3Chart.py", line 241, in <listcomp>
    serie = [{'x': x[i], 'y': y} for i, y in enumerate(y)]
TypeError: 'map' object is not subscriptable
```

Open to any feedback on the fix here, seemed lightest touch to just cast the map to a list since it's just generating sample data anyway.