### PR TITLE
Fix data provided to discreteBarChart example such that chart renders

### DIFF
--- a/examples/discreteBarChart.py
+++ b/examples/discreteBarChart.py
@@ -18,7 +18,7 @@ output_file = open('test_discreteBarChart.html', 'w')
 type = "discreteBarChart"
 chart = discreteBarChart(name='mygraphname', height=400, width=600)
 chart.set_containerheader("\n\n<h2>" + type + "</h2>\n\n")
-xdata = ["A", "B", "C", "D", "E", "F", "</script>G"]
+xdata = ["A", "B", "C", "D", "E", "F", "G"]
 ydata = [3, 12, -10, 5, 25, -7, 2]
 
 extra_serie = {"tooltip": {"y_start": "", "y_end": " cal"}}


### PR DESCRIPTION
Please let me know if there was a reason for this extra script tag (testing a bug that needs to be fixed elsewhere perhaps); otherwise seems like the fix here is straightforward.