### PR TITLE
Adds rendering option for bar charts show_values (issue #144)

### DIFF
--- a/nvd3/NVD3Chart.py
+++ b/nvd3/NVD3Chart.py
@@ -71,6 +71,7 @@ class NVD3Chart(object):
         :keyword: **margin_top** - default - ``30``
         :keyword: **height** - default - ``''``
         :keyword: **width** - default - ``''``
+        :keyword: **show_values** - default - ``False``
         :keyword: **stacked** - default - ``False``
         :keyword: **focus_enable** - default - ``False``
         :keyword: **resize** - define - ``False``
@@ -126,6 +127,7 @@ class NVD3Chart(object):
         self.margin_top = kwargs.get('margin_top', 30)
         self.height = kwargs.get('height', '')
         self.width = kwargs.get('width', '')
+        self.show_values = kwargs.get('show_values', False)
         self.stacked = kwargs.get('stacked', False)
         self.focus_enable = kwargs.get('focus_enable', False)
         self.resize = kwargs.get('resize', False)

--- a/nvd3/templates/content.html
+++ b/nvd3/templates/content.html
@@ -36,6 +36,9 @@
     {% if chart.show_controls == False %}
         chart.showControls(false);
     {% endif %}
+    {% if chart.show_values %}
+        chart.showValues(true);
+    {% endif %}
     {% endblock rendering_opts %}
 
     {% block focus %}


### PR DESCRIPTION
- defined near `stacked` which is also a bar chart specific option

Image of bar chart when this option is given:
![show-values-opt](https://user-images.githubusercontent.com/3665912/34725637-655a0aa6-f506-11e7-9b8f-312387c9c92e.png)

Put this together quickly in response to issue #144 and open to any feedback