### PR TITLE
Update python-slugify to at least 1.2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-python-slugify>=1.1.4
+python-slugify>=1.2.5
 Jinja2>=2.8

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'python-slugify==1.1.4',
+        'python-slugify>=1.2.5',
         'Jinja2>=2.8'
         # -*- Extra requirements: -*-
     ],


### PR DESCRIPTION
Some concerns were raised that python-slugify due
to its fixed dependency on GPL'd unidecode was
incompliant to the GPL (also making python-nvd3
possibly incompliant). Since version 1.2.5 python-
slugify allows an alternative to unidecode which
removes those concerns.

See: https://issues.apache.org/jira/browse/LEGAL-362
and: https://github.com/un33k/python-slugify/pull/53

As a side request I would highly appreciate a new release to pypi that pushed this change (and obviously bug fixes etc). The latest is from 2015 so others might appreciate and update as well :-).

Thanks for your consideration.
