### PR TITLE
fix tests; autogenerate examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,3 +161,9 @@ License
 -------
 
 Python-nvd3 is licensed under MIT, see `MIT-LICENSE.txt`.
+
+
+Maintainers
+-----------
+
+If you want to help maintain this project, please get it touch.

--- a/docs/source/classes-doc/examples/NVD3Chart.html
+++ b/docs/source/classes-doc/examples/NVD3Chart.html
@@ -1,0 +1,4 @@
+..
+    _Generated with generated_examples.sh script
+
+.. raw:: html

--- a/docs/source/classes-doc/examples/bulletChart.html
+++ b/docs/source/classes-doc/examples/bulletChart.html
@@ -1,0 +1,4 @@
+..
+    _Generated with generated_examples.sh script
+
+.. raw:: html

--- a/docs/source/classes-doc/examples/cumulativeLineChart.html
+++ b/docs/source/classes-doc/examples/cumulativeLineChart.html
@@ -1,0 +1,62 @@
+..
+    _Generated with generated_examples.sh script
+
+.. raw:: html
+        
+            <div id="cumulativelinechart"><svg style="height:450px;"></svg></div>
+        
+        
+            <script>
+        
+        
+        
+                data_cumulativelinechart=[{"values": [{"x": 1365026400000, "y": 6}, {"x": 1365026500000, "y": 5}, {"x": 1365026600000, "y": 1}], "key": "Serie 1", "yAxis": "1"}, {"values": [{"x": 1365026400000, "y": 36}, {"x": 1365026500000, "y": 55}, {"x": 1365026600000, "y": 11}], "key": "Serie 2", "yAxis": "1"}];
+        
+            nv.addGraph(function() {
+                var chart = nv.models.cumulativeLineChart();
+        
+                chart.margin({top: 30, right: 60, bottom: 20, left: 60});
+                chart.xAxis.rotateLabels(0)
+                chart.xAxis.staggerLabels(false)
+                chart.xAxis.showMaxMin(true)
+                var datum = data_cumulativelinechart;
+        
+        
+        
+        
+        
+        
+        
+                    chart.xAxis
+                        .tickFormat(function(d) { return d3.time.format('%d %b %Y')(new Date(parseInt(d))) }
+        );
+                    chart.yAxis
+                        .tickFormat(d3.format(',.1%'));
+        
+                           chart.tooltip.headerFormatter(function(d, i) {
+                               return d3.time.format("%d %b %Y")(new Date(parseInt(d)));
+                           });
+        
+              chart.showLegend(true);
+        
+        
+        
+                
+        
+        
+        
+                d3.select('#cumulativelinechart svg')
+                    .datum(datum)
+                    .transition().duration(500)
+                    .attr('height', 450)
+                    .call(chart);
+        
+        
+        
+            });
+        
+        
+        
+        
+            </script>
+        

--- a/docs/source/classes-doc/examples/discreteBarChart.html
+++ b/docs/source/classes-doc/examples/discreteBarChart.html
@@ -1,0 +1,58 @@
+..
+    _Generated with generated_examples.sh script
+
+.. raw:: html
+        
+            <div id="discretebarchart"><svg style="width:400px;height:400px;"></svg></div>
+        
+        
+            <script>
+        
+        
+        
+                        data_discretebarchart=[{"values": [{"x": "A", "y": 3}, {"x": "B", "y": 4}, {"x": "C", "y": 0}, {"x": "D", "y": -3}, {"x": "E", "y": 5}, {"x": "F", "y": 7}], "key": "Serie 1", "yAxis": "1"}];
+        
+        
+                    nv.addGraph(function() {
+                var chart = nv.models.discreteBarChart();
+        
+                chart.margin({top: 30, right: 60, bottom: 20, left: 60});
+                chart.xAxis.rotateLabels(0)
+                chart.xAxis.staggerLabels(false)
+                chart.xAxis.showMaxMin(true)
+                var datum = data_discretebarchart;
+        
+        
+        
+                
+        
+        
+        
+                            chart.yAxis
+                        .tickFormat(d3.format(',.0f'));
+        
+        
+                
+        
+            
+        
+                
+        
+        
+        
+                    d3.select('#discretebarchart svg')
+                    .datum(datum)
+                    .transition().duration(500)
+                    .attr('width', '400')
+                    .attr('height', 400)
+                    .call(chart);
+        
+        
+            
+        
+                });
+        
+        
+        
+            </script>
+        

--- a/docs/source/classes-doc/examples/lineChart.html
+++ b/docs/source/classes-doc/examples/lineChart.html
@@ -1,0 +1,71 @@
+..
+    _Generated with generated_examples.sh script
+
+.. raw:: html
+        
+            <div id="linechart"><svg style="height:450px;"></svg></div>
+        
+        
+            <script>
+        
+        
+        
+                    data_linechart=[{"values": [{"x": 0, "y": 0}, {"x": 1, "y": 0}, {"x": 2, "y": 1}, {"x": 3, "y": 1}, {"x": 4, "y": 0}, {"x": 5, "y": 0}, {"x": 6, "y": 0}, {"x": 7, "y": 0}, {"x": 8, "y": 1}, {"x": 9, "y": 0}, {"x": 10, "y": 0}, {"x": 11, "y": 4}, {"x": 12, "y": 3}, {"x": 13, "y": 3}, {"x": 14, "y": 5}, {"x": 15, "y": 7}, {"x": 16, "y": 5}, {"x": 17, "y": 3}, {"x": 18, "y": 16}, {"x": 19, "y": 6}, {"x": 20, "y": 9}, {"x": 21, "y": 15}, {"x": 22, "y": 4}, {"x": 23, "y": 12}], "key": "sine", "yAxis": "1"}, {"values": [{"x": 0, "y": 9}, {"x": 1, "y": 8}, {"x": 2, "y": 11}, {"x": 3, "y": 8}, {"x": 4, "y": 3}, {"x": 5, "y": 7}, {"x": 6, "y": 10}, {"x": 7, "y": 8}, {"x": 8, "y": 6}, {"x": 9, "y": 6}, {"x": 10, "y": 9}, {"x": 11, "y": 6}, {"x": 12, "y": 5}, {"x": 13, "y": 4}, {"x": 14, "y": 3}, {"x": 15, "y": 10}, {"x": 16, "y": 0}, {"x": 17, "y": 6}, {"x": 18, "y": 3}, {"x": 19, "y": 1}, {"x": 20, "y": 0}, {"x": 21, "y": 0}, {"x": 22, "y": 0}, {"x": 23, "y": 1}], "key": "cose", "yAxis": "1"}];
+        
+        
+                nv.addGraph(function() {
+                var chart = nv.models.lineChart();
+        
+                chart.margin({top: 30, right: 60, bottom: 20, left: 60});
+                chart.xAxis.rotateLabels(0)
+                chart.xAxis.staggerLabels(false)
+                chart.xAxis.showMaxMin(true)
+                var datum = data_linechart;
+        
+        
+        
+            
+        
+        
+        
+                        chart.xAxis
+                        .tickFormat(function(d) { return get_am_pm(parseInt(d)); });
+                    chart.yAxis
+                        .tickFormat(d3.format(',.02f'));
+        
+        
+                
+        
+                function get_am_pm(d){
+                    if (d > 12) {
+                        d = d - 12; return (String(d) + 'PM');
+                    }
+                    else {
+                        return (String(d) + 'AM');
+                    }
+                };
+        
+                  chart.showLegend(true);
+        
+        
+            
+        
+                
+        
+        
+        
+                    d3.select('#linechart svg')
+                    .datum(datum)
+                    .transition().duration(500)
+                    .attr('height', 450)
+                    .call(chart);
+        
+        
+            
+        
+                });
+        
+        
+        
+            </script>
+        

--- a/docs/source/classes-doc/examples/linePlusBarChart.html
+++ b/docs/source/classes-doc/examples/linePlusBarChart.html
@@ -1,0 +1,70 @@
+..
+    _Generated with generated_examples.sh script
+
+.. raw:: html
+        
+            <div id="lineplusbarchart"><svg style="width:500px;height:400px;"></svg></div>
+        
+        
+            <script>
+        
+        
+        
+                    data_lineplusbarchart=[{"values": [{"x": 1338501600000, "y": 6}, {"x": 1345501600000, "y": 5}, {"x": 1353501600000, "y": 1}], "key": "Serie 1", "yAxis": "1", "bar": "true"}, {"values": [{"x": 1338501600000, "y": 0.002}, {"x": 1345501600000, "y": 0.003}, {"x": 1353501600000, "y": 0.004}], "key": "Serie 2", "yAxis": "1"}];
+        
+        
+                nv.addGraph(function() {
+                var chart = nv.models.linePlusBarChart();
+        
+                chart.margin({top: 30, right: 60, bottom: 20, left: 60});
+                chart.xAxis.rotateLabels(0)
+                chart.xAxis.staggerLabels(false)
+                chart.xAxis.showMaxMin(true)
+                var datum = data_lineplusbarchart;
+        
+        
+        
+                chart.focusEnable(true);
+        
+                        chart.xAxis
+                        .tickFormat(function(d) { return d3.time.format('%d %b %Y')(new Date(parseInt(d))) }
+        );
+                    chart.x2Axis
+                        .tickFormat(function(d) { return d3.time.format('%d %b %Y')(new Date(parseInt(d))) }
+        );
+                    chart.y1Axis
+                        .tickFormat(function(d) { return d3.format(',f')(d) });
+                    chart.y2Axis
+                        .tickFormat(function(d) { return d3.format(',0.3f')(d) });
+        
+        
+                               chart.tooltip.headerFormatter(function(d, i) {
+                               return d3.time.format("%d %b %Y %H:%S")(new Date(parseInt(d)));
+                           });
+        
+        
+                  chart.showLegend(true);
+        
+        
+            
+        
+                
+        
+        
+        
+                    d3.select('#lineplusbarchart svg')
+                    .datum(datum)
+                    .transition().duration(500)
+                    .attr('width', '500')
+                    .attr('height', 400)
+                    .call(chart);
+        
+        
+            
+        
+                });
+        
+        
+        
+            </script>
+        

--- a/docs/source/classes-doc/examples/lineWithFocusChart.html
+++ b/docs/source/classes-doc/examples/lineWithFocusChart.html
@@ -1,0 +1,67 @@
+..
+    _Generated with generated_examples.sh script
+
+.. raw:: html
+        
+            <div id="linewithfocuschart"><svg style="height:450px;"></svg></div>
+        
+        
+            <script>
+        
+        
+            
+                data_linewithfocuschart=[{"values": [{"x": 1365026400000, "y": -6}, {"x": 1365026500000, "y": 5}, {"x": 1365026600000, "y": -1}, {"x": 1365026700000, "y": 2}, {"x": 1365026800000, "y": 4}, {"x": 1365026900000, "y": 8}, {"x": 1365027000000, "y": 10}], "key": "Serie 1", "yAxis": "1"}];
+        
+            nv.addGraph(function() {
+                var chart = nv.models.lineWithFocusChart();
+        
+                chart.margin({top: 30, right: 60, bottom: 20, left: 60});
+                chart.xAxis.rotateLabels(0)
+                chart.xAxis.staggerLabels(false)
+                chart.xAxis.showMaxMin(true)
+                var datum = data_linewithfocuschart;
+        
+        
+        
+        
+        
+        
+        
+                    chart.xAxis
+                        .tickFormat(function(d) { return d3.time.format('%d %b %Y')(new Date(parseInt(d))) }
+        );
+                    chart.x2Axis
+                        .tickFormat(function(d) { return d3.time.format('%d %b %Y')(new Date(parseInt(d))) }
+        );
+                    chart.yAxis
+                        .tickFormat(d3.format(',.2f'));
+                    chart.y2Axis
+                        .tickFormat(d3.format(',.2f'));
+        
+                           chart.tooltip.headerFormatter(function(d, i) {
+                               return d3.time.format("%d %b %Y")(new Date(parseInt(d)));
+                           });
+        
+              chart.showLegend(true);
+        
+        
+        
+                
+        
+        
+        
+                d3.select('#linewithfocuschart svg')
+                    .datum(datum)
+                    .transition().duration(500)
+                    .attr('height', 450)
+                    .call(chart);
+        
+        
+        
+            });
+        
+        
+        
+        
+            </script>
+        

--- a/docs/source/classes-doc/examples/multiBarChart.html
+++ b/docs/source/classes-doc/examples/multiBarChart.html
@@ -1,0 +1,57 @@
+..
+    _Generated with generated_examples.sh script
+
+.. raw:: html
+        
+            <div id="multibarchart"><svg style="width:500px;height:400px;"></svg></div>
+        
+        
+            <script>
+        
+        
+        
+                data_multibarchart=[{"values": [{"x": "one", "y": 6}, {"x": "two", "y": 12}, {"x": "three", "y": 9}, {"x": "four", "y": 16}], "key": "Serie 1", "yAxis": "1"}, {"values": [{"x": "one", "y": 8}, {"x": "two", "y": 14}, {"x": "three", "y": 7}, {"x": "four", "y": 11}], "key": "Serie 2", "yAxis": "1"}];
+        
+            nv.addGraph(function() {
+                var chart = nv.models.multiBarChart();
+        
+                chart.margin({top: 30, right: 60, bottom: 20, left: 60});
+                chart.xAxis.rotateLabels(0)
+                chart.xAxis.staggerLabels(false)
+                chart.xAxis.showMaxMin(true)
+                var datum = data_multibarchart;
+        
+        
+        
+        
+        
+        
+        
+                    chart.yAxis
+                        .tickFormat(d3.format(',.2f'));
+        
+        
+              chart.showLegend(true);
+        
+        
+        
+                
+        
+        
+        
+                d3.select('#multibarchart svg')
+                    .datum(datum)
+                    .transition().duration(500)
+                    .attr('width', '500')
+                    .attr('height', 400)
+                    .call(chart);
+        
+        
+        
+            });
+        
+        
+        
+        
+            </script>
+        

--- a/docs/source/classes-doc/examples/multiBarHorizontalChart.html
+++ b/docs/source/classes-doc/examples/multiBarHorizontalChart.html
@@ -1,0 +1,59 @@
+..
+    _Generated with generated_examples.sh script
+
+.. raw:: html
+        
+            <div id="multibarhorizontalchart"><svg style="width:400px;height:400px;"></svg></div>
+        
+        
+            <script>
+        
+        
+        
+                data_multibarhorizontalchart=[{"values": [{"x": -14, "y": -6}, {"x": -7, "y": 5}, {"x": 7, "y": -1}, {"x": 14, "y": 9}], "key": "Serie 1", "yAxis": "1"}, {"values": [{"x": -14, "y": -23}, {"x": -7, "y": -6}, {"x": 7, "y": -32}, {"x": 14, "y": 9}], "key": "Serie 2", "yAxis": "1"}];
+        
+            nv.addGraph(function() {
+                var chart = nv.models.multiBarHorizontalChart();
+        
+                chart.margin({top: 30, right: 60, bottom: 20, left: 60});
+                chart.xAxis.rotateLabels(0)
+                chart.xAxis.staggerLabels(false)
+                chart.xAxis.showMaxMin(true)
+                var datum = data_multibarhorizontalchart;
+        
+        
+        
+        
+        
+        
+        
+                    chart.xAxis
+                        .tickFormat(d3.format(',.2f'));
+                    chart.yAxis
+                        .tickFormat(d3.format(',.2f'));
+        
+        
+              chart.showLegend(true);
+        
+        
+        
+                
+        
+        
+        
+                d3.select('#multibarhorizontalchart svg')
+                    .datum(datum)
+                    .transition().duration(500)
+                    .attr('width', '400')
+                    .attr('height', 400)
+                    .call(chart);
+        
+        
+        
+            });
+        
+        
+        
+        
+            </script>
+        

--- a/docs/source/classes-doc/examples/multiChart.html
+++ b/docs/source/classes-doc/examples/multiChart.html
@@ -1,0 +1,4 @@
+..
+    _Generated with generated_examples.sh script
+
+.. raw:: html

--- a/docs/source/classes-doc/examples/pieChart.html
+++ b/docs/source/classes-doc/examples/pieChart.html
@@ -1,0 +1,62 @@
+..
+    _Generated with generated_examples.sh script
+
+.. raw:: html
+        
+            <div id="piechart"><svg style="width:400px;height:400px;"></svg></div>
+        
+        
+            <script>
+        
+        
+        
+            data_piechart=[{"values": [{"label": "Orange", "value": 3}, {"label": "Banana", "value": 4}, {"label": "Pear", "value": 0}, {"label": "Kiwi", "value": 1}, {"label": "Apple", "value": 5}, {"label": "Strawbery", "value": 7}, {"label": "Pineapple", "value": 3}], "key": "Serie 1"}];
+        
+            nv.addGraph(function() {
+                var chart = nv.models.pieChart();
+                chart.margin({top: 30, right: 60, bottom: 20, left: 60});
+                var datum = data_piechart[0].values;
+        
+                chart.color(d3.scale.category20c().range());
+        
+            chart.tooltip.contentGenerator(function(d, elem) {
+                  var x = String(d.data.label);
+                  var y = String(d.data.value);
+                      tooltip_str = '<center><b>'+x+'</b></center>' + y;
+                      return tooltip_str;
+                      });
+                chart.showLabels(true);
+        
+                    chart.donut(false);
+        
+            chart.showLegend(true);
+        
+        
+        
+        
+                chart
+                    .x(function(d) { return d.label })
+                    .y(function(d) { return d.value });
+        
+                chart.width(400);
+        
+                chart.height(400);
+        
+        
+        
+                    d3.select('#piechart svg')
+                    .datum(datum)
+                    .transition().duration(500)
+                    .attr('width', '400')
+                    .attr('height', 400)
+                    .call(chart);
+        
+        
+        
+        
+                });
+        
+        
+        
+            </script>
+        

--- a/docs/source/classes-doc/examples/scatterChart.html
+++ b/docs/source/classes-doc/examples/scatterChart.html
@@ -1,0 +1,68 @@
+..
+    _Generated with generated_examples.sh script
+
+.. raw:: html
+        
+            <div id="scatterchart"><svg style="width:400px;height:400px;"></svg></div>
+        
+        
+            <script>
+        
+        
+        
+                    data_scatterchart=[{"values": [{"x": 3, "y": -1, "shape": "circle", "size": "1"}, {"x": 4, "y": 2, "shape": "circle", "size": "1"}, {"x": 0, "y": 3, "shape": "circle", "size": "1"}, {"x": -3, "y": 3, "shape": "circle", "size": "1"}, {"x": 5, "y": 15, "shape": "circle", "size": "1"}, {"x": 7, "y": 2, "shape": "circle", "size": "1"}], "key": "series 1", "yAxis": "1"}, {"values": [{"x": 3, "y": 1, "shape": "cross", "size": "10"}, {"x": 4, "y": -2, "shape": "cross", "size": "10"}, {"x": 0, "y": 4, "shape": "cross", "size": "10"}, {"x": -3, "y": 7, "shape": "cross", "size": "10"}, {"x": 5, "y": -5, "shape": "cross", "size": "10"}, {"x": 7, "y": 3, "shape": "cross", "size": "10"}], "key": "series 2", "yAxis": "1"}];
+        
+        
+                nv.addGraph(function() {
+                var chart = nv.models.scatterChart();
+        
+                chart.margin({top: 30, right: 60, bottom: 20, left: 60});
+                chart.xAxis.rotateLabels(0)
+                chart.xAxis.staggerLabels(false)
+                chart.xAxis.showMaxMin(true)
+                var datum = data_scatterchart;
+        
+        
+        
+            
+        
+        
+        
+                        chart.xAxis
+                        .tickFormat(d3.format(',.02f'));
+                    chart.yAxis
+                        .tickFormat(d3.format(',.02f'));
+        
+        
+        
+                  chart.showLegend(true);
+        
+        
+            
+        
+                
+        
+        
+        
+        
+            chart
+                .showDistX(true)
+                .showDistY(true)
+                .color(d3.scale.category10().range());
+        
+                    d3.select('#scatterchart svg')
+                    .datum(datum)
+                    .transition().duration(500)
+                    .attr('width', '400')
+                    .attr('height', 400)
+                    .call(chart);
+        
+        
+            
+        
+                });
+        
+        
+        
+            </script>
+        

--- a/docs/source/classes-doc/examples/stackedAreaChart.html
+++ b/docs/source/classes-doc/examples/stackedAreaChart.html
@@ -1,0 +1,57 @@
+..
+    _Generated with generated_examples.sh script
+
+.. raw:: html
+        
+            <div id="stackedareachart"><svg style="width:400px;height:400px;"></svg></div>
+        
+        
+            <script>
+        
+        
+                    data_stackedareachart=[{"values": [{"x": 100, "y": 6}, {"x": 101, "y": 11}, {"x": 102, "y": 12}, {"x": 103, "y": 7}, {"x": 104, "y": 11}, {"x": 105, "y": 10}, {"x": 106, "y": 11}], "key": "Serie 1", "yAxis": "1"}, {"values": [{"x": 100, "y": 8}, {"x": 101, "y": 20}, {"x": 102, "y": 16}, {"x": 103, "y": 12}, {"x": 104, "y": 20}, {"x": 105, "y": 28}, {"x": 106, "y": 28}], "key": "Serie 2", "yAxis": "1"}];
+        
+            nv.addGraph(function() {
+                var chart = nv.models.stackedAreaChart();
+        
+                chart.margin({top: 30, right: 60, bottom: 20, left: 60});
+                chart.xAxis.rotateLabels(0)
+                chart.xAxis.staggerLabels(false)
+                chart.xAxis.showMaxMin(true)
+                var datum = data_stackedareachart;
+        
+        
+        
+        
+        
+        
+        
+                    chart.xAxis
+                        .tickFormat(d3.format(',.2f'));
+                    chart.yAxis
+                        .tickFormat(d3.format(',.2f'));
+        
+        
+              chart.showLegend(true);
+        
+        
+        
+                
+        
+        
+        
+                d3.select('#stackedareachart svg')
+                    .datum(datum)
+                    .transition().duration(500)
+                    .attr('width', '400')
+                    .attr('height', 400)
+                    .call(chart);
+        
+        
+        
+            });
+        
+        
+        
+            </script>
+        

--- a/generate_examples.sh
+++ b/generate_examples.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+mkdir "docs/source/classes-doc/examples/"
+for file in nvd3/*Chart.py; do
+   html_filename="docs/source/classes-doc/examples/"`echo $file | sed "s/.*\///" | sed "s/\.py//"`".html"
+   echo $html_filename
+   echo -e "..\n    _Generated with generated_examples.sh script\n\n.. raw:: html" > $html_filename
+
+   cat $file | grep "Python example" -A1000 | grep -E "Javascript generated|Note that in case you" -m 1 -B 1000 | tail -n+2 | head -n-1 | sed "s/^[ \t]*//g" | python | sed "s/^/        /" >> $html_filename
+done
+

--- a/nvd3/bulletChart.py
+++ b/nvd3/bulletChart.py
@@ -35,53 +35,11 @@ class bulletChart(TemplateMixin, NVD3Chart):
             measures=measures,
             markers=markers)
         chart.buildhtml()
+        print(chart.content)
 
     JavaScript generated:
 
-    .. raw:: html
-
-        <!DOCTYPE html>
-        <html lang="en">
-            <head>
-                <meta charset="utf-8" />
-                <link href="https://cdnjs.cloudflare.com/ajax/libs/nvd3/1.8.6/nv.d3.min.css" rel="stylesheet" />
-                <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
-                <script src="https://cdnjs.cloudflare.com/ajax/libs/nvd3/1.8.6/nv.d3.min.js"></script>
-            </head>
-            <body>
-
-            <div id="bulletchart"><svg style="width:500px;height:100px;"></svg></div>
-
-
-            <script>
-
-
-
-                    data_bulletchart=[{"key": "Serie 1", "values": [{"title": ["Revenue"], "subtitle": "USD, in mill", "ranges": [100, 250, 300], "measures": [220, 280]}]}];
-
-
-            function transformedData(){
-                return data_bulletchart[0]['values'][0]
-            }
-
-
-
-            nv.addGraph(function() {
-            var chart = nv.models.bulletChart();
-
-            d3.select('svg')
-                .datum(transformedData())
-                .transition().duration(1000)
-                .call(chart)
-                ;
-
-            return chart;
-            });
-
-            </script>
-
-            </body>
-        </html>
+    .. include:: ./examples/bulletChart.html
 
     '''
     CHART_FILENAME = './bulletchart.html'

--- a/nvd3/cumulativeLineChart.py
+++ b/nvd3/cumulativeLineChart.py
@@ -31,49 +31,14 @@ class cumulativeLineChart(TemplateMixin, NVD3Chart):
         extra_serie = {"tooltip": {"y_start": "", "y_end": " mins"}}
         chart.add_serie(name="Serie 2", y=y2data, x=xdata, extra=extra_serie)
         chart.buildhtml()
+        print(chart.content)
+
 
     Javascript generated:
 
-    .. raw:: html
 
-        <div id="cumulativeLineChart"><svg style="height:450px; width:100%"></svg></div>
-        <script>
-            data_cumulativeLineChart=[{"values": [{"y": 6, "x": 1365026400000},
-            {"y": 5, "x": 1365026500000},
-            {"y": 1, "x": 1365026600000}],
-            "key": "Serie 1", "yAxis": "1"},
-            {"values": [{"y": 36, "x": 1365026400000},
-            {"y": 55, "x": 1365026500000},
-            {"y": 11, "x": 1365026600000}], "key": "Serie 2", "yAxis": "1"}];
-            nv.addGraph(function() {
-                var chart = nv.models.cumulativeLineChart();
-                chart.margin({top: 30, right: 60, bottom: 20, left: 60});
-                var datum = data_cumulativeLineChart;
+    .. include:: ./examples/cumulativeLineChart.html
 
-                        chart.xAxis
-                            .tickFormat(function(d) { return d3.time.format('%d %b %Y')(new Date(parseInt(d))) });
-                        chart.yAxis
-                            .tickFormat(d3.format(',.1%'));
-
-                    chart.tooltipContent(function(key, y, e, graph) {
-                        var x = d3.time.format("%d %b %Y")(new Date(parseInt(graph.point.x)));
-                        var y = String(graph.point.y);
-                        if(key == 'Serie 1'){
-                                var y = 'There are ' +  String(e)  + ' calls';
-                            }if(key == 'Serie 2'){
-                                var y =  String(e)  + ' mins';
-                            }
-                        tooltip_str = '<center><b>'+key+'</b></center>' + y + ' on ' + x;
-                        return tooltip_str;
-                    });
-                    chart.showLegend(true);
-
-                d3.select('#cumulativeLineChart svg')
-                    .datum(datum)
-                    .transition().duration(500)
-                    .attr('height', 450)
-                    .call(chart); });
-        </script>
 
     """
 

--- a/nvd3/discreteBarChart.py
+++ b/nvd3/discreteBarChart.py
@@ -28,40 +28,12 @@ class discreteBarChart(TemplateMixin, NVD3Chart):
 
         chart.add_serie(y=ydata, x=xdata)
         chart.buildhtml()
+        print(chart.content)
 
     Javascript generated:
 
-    .. raw:: html
+    .. include:: ./examples/discreteBarChart.html
 
-        <div id="discreteBarChart"><svg style="height:450px; width:100%"></svg></div>
-        <script>
-            data_discreteBarChart=[{"values": [{"y": 3, "x": "A"}, {"y": 4, "x": "B"}, {"y": 0, "x": "C"}, {"y": -3, "x": "D"}, {"y": 5, "x": "E"}, {"y": 7, "x": "F"}], "key": "Serie 1", "yAxis": "1"}];
-
-            nv.addGraph(function() {
-                var chart = nv.models.discreteBarChart();
-
-                chart.margin({top: 30, right: 60, bottom: 20, left: 60});
-
-                var datum = data_discreteBarChart;
-                        chart.yAxis
-                            .tickFormat(d3.format(',.0f'));
-                        chart.tooltipContent(function(key, y, e, graph) {
-                            var x = String(graph.point.x);
-                            var y = String(graph.point.y);
-                            var y = String(graph.point.y);
-
-                            tooltip_str = '<center><b>'+key+'</b></center>' + y + ' at ' + x;
-                            return tooltip_str;
-                        });
-
-                d3.select('#discreteBarChart svg')
-                    .datum(datum)
-                    .transition().duration(500)
-                    .attr('width', 400)
-                    .attr('height', 400)
-                    .call(chart);
-            });
-        </script>
 
 
     You can also disable the tooltips by passing ``tooltips=False`` when

--- a/nvd3/lineChart.py
+++ b/nvd3/lineChart.py
@@ -28,60 +28,15 @@ class lineChart(TemplateMixin, NVD3Chart):
         ydata2 = [9, 8, 11, 8, 3, 7, 10, 8, 6, 6, 9, 6, 5, 4, 3, 10, 0, 6, 3, 1, 0, 0, 0, 1]
 
         extra_serie = {"tooltip": {"y_start": "There are ", "y_end": " calls"}}
-        chart.add_serie(y=ydata, x=xdata, name='sine', extra=extra_serie, **kwargs1)
+        chart.add_serie(y=ydata, x=xdata, name='sine', extra=extra_serie)
         extra_serie = {"tooltip": {"y_start": "", "y_end": " min"}}
-        chart.add_serie(y=ydata2, x=xdata, name='cose', extra=extra_serie, **kwargs2)
+        chart.add_serie(y=ydata2, x=xdata, name='cose', extra=extra_serie)
         chart.buildhtml()
+        print(chart.content)
 
-    Javascript rendered to:
+    Javascript generated:
 
-    .. raw:: html
-
-        <div id="lineChart"><svg style="height:450px; width:100%"></svg></div>
-        <script>
-
-            data_lineChart=[{"values": [{"y": 0, "x": 0}, {"y": 0, "x": 1}, {"y": 1, "x": 2}, {"y": 1, "x": 3}, {"y": 0, "x": 4}, {"y": 0, "x": 5}, {"y": 0, "x": 6}, {"y": 0, "x": 7}, {"y": 1, "x": 8}, {"y": 0, "x": 9}, {"y": 0, "x": 10}, {"y": 4, "x": 11}, {"y": 3, "x": 12}, {"y": 3, "x": 13}, {"y": 5, "x": 14}, {"y": 7, "x": 15}, {"y": 5, "x": 16}, {"y": 3, "x": 17}, {"y": 16, "x": 18}, {"y": 6, "x": 19}, {"y": 9, "x": 20}, {"y": 15, "x": 21}, {"y": 4, "x": 22}, {"y": 12, "x": 23}], "key": "sine", "yAxis": "1"}, {"values": [{"y": 9, "x": 0}, {"y": 8, "x": 1}, {"y": 11, "x": 2}, {"y": 8, "x": 3}, {"y": 3, "x": 4}, {"y": 7, "x": 5}, {"y": 10, "x": 6}, {"y": 8, "x": 7}, {"y": 6, "x": 8}, {"y": 6, "x": 9}, {"y": 9, "x": 10}, {"y": 6, "x": 11}, {"y": 5, "x": 12}, {"y": 4, "x": 13}, {"y": 3, "x": 14}, {"y": 10, "x": 15}, {"y": 0, "x": 16}, {"y": 6, "x": 17}, {"y": 3, "x": 18}, {"y": 1, "x": 19}, {"y": 0, "x": 20}, {"y": 0, "x": 21}, {"y": 0, "x": 22}, {"y": 1, "x": 23}], "key": "cose", "yAxis": "1"}];
-
-            nv.addGraph(function() {
-                var chart = nv.models.lineChart();
-                chart.margin({top: 30, right: 60, bottom: 20, left: 60});
-                var datum = data_lineChart;
-                        chart.xAxis
-                            .tickFormat(function(d) { return get_am_pm(parseInt(d)); });
-                        chart.yAxis
-                            .tickFormat(d3.format(',.02f'));
-
-                        chart.tooltipContent(function(key, y, e, graph) {
-                            var x = String(graph.point.x);
-                            var y = String(graph.point.y);
-                                                if(key == 'sine'){
-                                var y = 'There is ' +  String(graph.point.y)  + ' calls';
-                            }
-                            if(key == 'cose'){
-                                var y =  String(graph.point.y)  + ' min';
-                            }
-
-                            tooltip_str = '<center><b>'+key+'</b></center>' + y + ' at ' + x;
-                            return tooltip_str;
-                        });
-                    chart.showLegend(true);
-                        function get_am_pm(d){
-                    if (d > 12) {
-                        d = d - 12; return (String(d) + 'PM');
-                    }
-                    else {
-                        return (String(d) + 'AM');
-                    }
-                };
-
-                d3.select('#lineChart svg')
-                    .datum(datum)
-                    .transition().duration(500)
-                    .attr('height', 200)
-                    .call(chart);
-            return chart;
-        });
-        </script>
+    .. include:: ./examples/lineChart.html
 
     See the source code of this page, to see the underlying javascript.
     """

--- a/nvd3/linePlusBarChart.py
+++ b/nvd3/linePlusBarChart.py
@@ -39,7 +39,8 @@ class linePlusBarChart(TemplateMixin, NVD3Chart):
 
         extra_serie = {"tooltip": {"y_start": "There are ", "y_end": " min"}}
         chart.add_serie(name="Serie 2", y=y2data, x=xdata, extra=extra_serie)
-        chart.buildcontent()
+        chart.buildhtml()
+        print(chart.content)
 
     Note that in case you have two data serie with extreme different numbers,
     that you would like to format in different ways,
@@ -51,44 +52,7 @@ class linePlusBarChart(TemplateMixin, NVD3Chart):
 
     Javascript generated:
 
-    .. raw:: html
-
-        <div id="linePlusBarChart"><svg style="height:450px; width:100%"></svg></div>
-        <script>
-            data_linePlusBarChart=[{"bar": "true", "values": [{"y": 6, "x": 1338501600000}, {"y": 5, "x": 1345501600000}, {"y": 1, "x": 1353501600000}], "key": "Serie 1", "yAxis": "1"}, {"values": [{"y": 0.002, "x": 1338501600000}, {"y": 0.003, "x": 1345501600000}, {"y": 0.004, "x": 1353501600000}], "key": "Serie 2", "yAxis": "1"}];
-            nv.addGraph(function() {
-                var chart = nv.models.linePlusBarChart();
-                chart.margin({top: 30, right: 60, bottom: 20, left: 60});
-                var datum = data_linePlusBarChart;
-
-                    chart.y2Axis
-                        .tickFormat(function(d) { return d3.format(',0.3f')(d) });
-                    chart.xAxis
-                        .tickFormat(function(d) { return d3.time.format('%d %b %Y')(new Date(parseInt(d))) });
-                    chart.y1Axis
-                        .tickFormat(function(d) { return d3.format(',f')(d) });
-
-                    chart.tooltipContent(function(key, y, e, graph) {
-                        var x = d3.time.format("%d %b %Y %H:%S")(new Date(parseInt(graph.point.x)));
-                        var y = String(graph.point.y);
-                        if(key.indexOf('Serie 1') > -1 ){
-                                var y = 'There are ' +  String(graph.point.y)  + ' calls';
-                            }
-                            if(key.indexOf('Serie 2') > -1 ){
-                                var y = 'There are ' +  String(graph.point.y)  + ' min';
-                            }
-                        tooltip_str = '<center><b>'+key+'</b></center>' + y + ' on ' + x;
-                        return tooltip_str;
-                    });
-                    chart.showLegend(true);
-                d3.select('#linePlusBarChart svg')
-                    .datum(datum)
-                    .transition().duration(500)
-                    .attr('width', 500)
-                    .attr('height', 400)
-                    .call(chart);
-            });
-        </script>
+    .. include:: ./examples/linePlusBarChart.html
 
     """
     CHART_FILENAME = "./lineplusbarchart.html"

--- a/nvd3/lineWithFocusChart.py
+++ b/nvd3/lineWithFocusChart.py
@@ -30,45 +30,12 @@ class lineWithFocusChart(TemplateMixin, NVD3Chart):
                        "date_format": "%d %b %Y"}
         chart.add_serie(name="Serie 1", y=ydata, x=xdata, extra=extra_serie)
         chart.buildhtml()
+        print(chart.content)
 
     Javascript generated:
 
-    .. raw:: html
+    .. include:: ./examples/lineWithFocusChart.html
 
-        <div id="lineWithFocusChart"><svg style="height:450px; width:100%"></svg></div>
-        <script>
-            data_lineWithFocusChart=[{"values": [{"y": -6, "x": 1365026400000}, {"y": 5, "x": 1365026500000}, {"y": -1, "x": 1365026600000}], "key": "Serie 1", "yAxis": "1"}];
-            nv.addGraph(function() {
-                var chart = nv.models.lineWithFocusChart();
-                chart.margin({top: 30, right: 60, bottom: 20, left: 60});
-                var datum = data_lineWithFocusChart;
-                        chart.yAxis
-                            .tickFormat(d3.format(',.2f'));
-                        chart.y2Axis
-                            .tickFormat(d3.format(',.2f'));
-                        chart.xAxis
-                            .tickFormat(function(d) { return d3.time.format('%d %b %Y')(new Date(parseInt(d))) });
-                        chart.x2Axis
-                            .tickFormat(function(d) { return d3.time.format('%d %b %Y')(new Date(parseInt(d))) });
-
-                    chart.tooltipContent(function(key, y, e, graph) {
-                        var x = d3.time.format("%d %b %Y")(new Date(parseInt(graph.point.x)));
-                        var y = String(graph.point.y);
-                                            if(key == 'Serie 1'){
-                                var y =  String(graph.point.y)  + ' ext';
-                            }
-
-                        tooltip_str = '<center><b>'+key+'</b></center>' + y + ' on ' + x;
-                        return tooltip_str; });
-
-                    chart.showLegend(true);
-
-                d3.select('#lineWithFocusChart svg')
-                    .datum(datum)
-                    .transition().duration(500)
-                    .attr('height', 450)
-                    .call(chart); });
-        </script>
 
     """
 

--- a/nvd3/multiBarChart.py
+++ b/nvd3/multiBarChart.py
@@ -30,44 +30,11 @@ class multiBarChart(TemplateMixin, NVD3Chart):
         chart.add_serie(name="Serie 1", y=ydata1, x=xdata)
         chart.add_serie(name="Serie 2", y=ydata2, x=xdata)
         chart.buildhtml()
+        print(chart.content)
 
     Javascript generated:
 
-    .. raw:: html
-
-        <div id="multiBarChart"><svg style="height:450px; width:100%"></svg></div>
-        <script>
-
-            data_multiBarChart=[{"values":
-                                [{"y": 6, "x": "one"},
-                                {"y": 12, "x": "two"},
-                                {"y": 9, "x": "three"},
-                                {"y": 16, "x": "four"}],
-                                "key": "Serie 1", "yAxis": "1"},
-                                {"values":
-                                    [{"y": 8, "x": "one"},
-                                    {"y": 14, "x": "two"},
-                                    {"y": 7, "x": "three"},
-                                    {"y": 11, "x": "four"}],
-                                "key": "Serie 2", "yAxis": "1"}];
-
-            nv.addGraph(function() {
-                var chart = nv.models.multiBarChart();
-                chart.margin({top: 30, right: 60, bottom: 20, left: 60});
-                var datum = data_multiBarChart;
-                        chart.yAxis
-                            .tickFormat(d3.format(',.2f'));
-                    chart.showLegend(true);
-                d3.select('#multiBarChart svg')
-                    .datum(datum)
-                    .transition().duration(500)
-                    .attr('width', 500)
-                    .attr('height', 400)
-                    .call(chart);
-            });
-
-
-        </script>
+    .. include:: ./examples/multiBarChart.html
 
     """
 

--- a/nvd3/multiBarHorizontalChart.py
+++ b/nvd3/multiBarHorizontalChart.py
@@ -29,58 +29,12 @@ class multiBarHorizontalChart(TemplateMixin, NVD3Chart):
 
         extra_serie = {"tooltip": {"y_start": "", "y_end": " calls"}}
         chart.add_serie(name="Serie 2", y=y2data, x=xdata, extra=extra_serie)
-        chart.buildcontent()
+        chart.buildhtml()
+        print(chart.content)
 
     Javascript generated:
 
-    .. raw:: html
-
-        <div id="multiBarHorizontalChart"><svg style="height:450px; width:100%"></svg></div>
-        <script>
-
-            data_multiBarHorizontalChart=[{"values":
-                [{"y": -6, "x": -14}, {"y": 5, "x": -7}, {"y": -1, "x": 7}, {"y": 9, "x": 14}],
-                "key": "Serie 1", "yAxis": "1"},
-                {"values":
-                    [{"y": -23, "x": -14}, {"y": -6, "x": -7}, {"y": -32, "x": 7}, {"y": 9, "x": 14}],
-                "key": "Serie 2", "yAxis": "1"}];
-
-            nv.addGraph(function() {
-                var chart = nv.models.multiBarHorizontalChart();
-
-                chart.margin({top: 30, right: 60, bottom: 20, left: 60});
-
-                var datum = data_multiBarHorizontalChart;
-
-                        chart.xAxis
-                            .tickFormat(d3.format(',.2f'));
-                        chart.yAxis
-                            .tickFormat(d3.format(',.2f'));
-
-                        chart.tooltipContent(function(key, y, e, graph) {
-                            var x = String(graph.point.x);
-                            var y = String(graph.point.y);
-                                                if(key == 'Serie 1'){
-                                var y =  String(graph.point.y)  + ' balls';
-                            }
-                            if(key == 'Serie 2'){
-                                var y =  String(graph.point.y)  + ' calls';
-                            }
-
-                            tooltip_str = '<center><b>'+key+'</b></center>' + y + ' at ' + x;
-                            return tooltip_str;
-                        });
-
-                    chart.showLegend(true);
-
-                d3.select('#multiBarHorizontalChart svg')
-                    .datum(datum)
-                    .transition().duration(500)
-                    .attr('width', 400)
-                    .attr('height', 400)
-                    .call(chart);
-            });
-        </script>
+    .. include:: ./examples/multiBarHorizontalChart.html
 
     """
 

--- a/nvd3/multiChart.py
+++ b/nvd3/multiChart.py
@@ -34,52 +34,12 @@ class multiChart(TemplateMixin, NVD3Chart):
         extra_serie = {"tooltip": {"y_start": "", "y_end": " min"}}
         chart.add_serie(y=ydata2, x=xdata, type='bar', yaxis=2,name='spend', extra=extra_serie, **kwargs2)
         chart.buildhtml()
+        print(chart.content)
 
 
     Javascript renderd to:
 
-    .. raw:: html
-
-    <div id="multichart"><svg style="height:450px;"></svg></div>
-    <script>
-
-            data_multichart=[{"color": "black", "type": "line", "values": [{"y": 115.5, "x": 1}, {"y": 160.5, "x": 2}, {"y": 108, "x": 3}, {"y
-": 145.5, "x": 4}, {"y": 84, "x": 5}, {"y": 70.5, "x": 6}], "key": "visits", "yAxis": 1}, {"color": "red", "type": "bar", "values": [{"y": 486
-24, "x": 1}, {"y": 42944, "x": 2}, {"y": 43439, "x": 3}, {"y": 24194, "x": 4}, {"y": 38440, "x": 5}, {"y": 31651, "x": 6}], "key": "spend", "y
-Axis": 2}];
-
-        nv.addGraph(function() {
-        var chart = nv.models.multiChart();
-
-        chart.margin({top: 30, right: 60, bottom: 20, left: 60});
-
-        var datum = data_multichart;
-        
-                chart.yAxis1
-                .tickFormat(d3.format(',.02f'));
-            chart.yAxis2
-                .tickFormat(d3.format(',.02f'));
-            chart.xAxis
-                .tickFormat(function(d) { return get_am_pm(parseInt(d)); });
-
-        function get_am_pm(d){
-            if (d > 12) {
-                d = d - 12; return (String(d) + 'PM');
-            }
-            else {
-                return (String(d) + 'AM');
-            }
-        };
-
-          chart.showLegend(true);
-          
-            d3.select('#multichart svg')
-            .datum(datum)
-            .transition().duration(500)
-            .attr('height', 450)
-            .call(chart);
-        });
-    </script>
+    .. include:: ./examples/multiChart.html
 
     See the source code of this page, to see the underlying javascript.
     """

--- a/nvd3/pieChart.py
+++ b/nvd3/pieChart.py
@@ -32,51 +32,11 @@ class pieChart(TemplateMixin, NVD3Chart):
         extra_serie = {"tooltip": {"y_start": "", "y_end": " cal"}}
         chart.add_serie(y=ydata, x=xdata, extra=extra_serie)
         chart.buildhtml()
+        print(chart.content)
 
     Javascript generated:
 
-    .. raw:: html
-
-        <div id="pieChart"><svg style="height:450px; width:100%"></svg></div>
-        <script>
-
-
-            data_pieChart=[{"values": [{"value": 3, "label": "Orange"},
-                           {"value": 4, "label": "Banana"},
-                           {"value": 0, "label": "Pear"},
-                           {"value": 1, "label": "Kiwi"},
-                           {"value": 5, "label": "Apple"},
-                           {"value": 7, "label": "Strawberry"},
-                           {"value": 3, "label": "Pineapple"}],
-                           "key": "Serie 1"}];
-
-            nv.addGraph(function() {
-                var chart = nv.models.pieChart();
-                chart.margin({top: 30, right: 60, bottom: 20, left: 60});
-                var datum = data_pieChart[0].values;
-                        chart.tooltipContent(function(key, y, e, graph) {
-                            var x = String(key);
-                            var y =  String(y)  + ' cal';
-
-                            tooltip_str = '<center><b>'+x+'</b></center>' + y;
-                            return tooltip_str;
-                        });
-                    chart.showLegend(true);
-                    chart.showLabels(true);
-                    chart.donut(false);
-                chart
-                    .x(function(d) { return d.label })
-                    .y(function(d) { return d.value });
-                chart.width(400);
-                chart.height(400);
-
-                d3.select('#pieChart svg')
-                    .datum(datum)
-                    .transition().duration(500)
-                    .attr('width', 400)
-                    .attr('height', 400)
-                    .call(chart);  });
-        </script>
+    .. include:: ./examples/pieChart.html
 
     """
     CHART_FILENAME = "./piechart.html"

--- a/nvd3/scatterChart.py
+++ b/nvd3/scatterChart.py
@@ -38,69 +38,11 @@ class scatterChart(TemplateMixin, NVD3Chart):
         extra_serie = {"tooltip": {"y_start": "", "y_end": " min"}}
         chart.add_serie(name="series 2", y=ydata2, x=xdata, extra=extra_serie, **kwargs2)
         chart.buildhtml()
+        print(chart.content)
 
     Javascript generated:
 
-    .. raw:: html
-
-        <div id="scatterChart"><svg style="height:450px; width:100%"></svg></div>
-        <script>
-
-        data_scatterChart=[{"values": [{"y": -1, "x": 3, "shape": "circle",
-            "size": "1"}, {"y": 2, "x": 4, "shape": "circle", "size": "1"},
-            {"y": 3, "x": 0, "shape": "circle", "size": "1"},
-            {"y": 3, "x": -3, "shape": "circle", "size": "1"},
-            {"y": 15, "x": 5, "shape": "circle", "size": "1"},
-            {"y": 2, "x": 7, "shape": "circle", "size": "1"}],
-            "key": "series 1", "yAxis": "1"},
-            {"values": [{"y": 1, "x": 3, "shape": "cross", "size": "10"},
-            {"y": -2, "x": 4, "shape": "cross", "size": "10"},
-            {"y": 4, "x": 0, "shape": "cross", "size": "10"},
-            {"y": 7, "x": -3, "shape": "cross", "size": "10"},
-            {"y": -5, "x": 5, "shape": "cross", "size": "10"},
-            {"y": 3, "x": 7, "shape": "cross", "size": "10"}],
-            "key": "series 2", "yAxis": "1"}];
-        nv.addGraph(function() {
-        var chart = nv.models.scatterChart();
-
-        chart.margin({top: 30, right: 60, bottom: 20, left: 60});
-
-        var datum = data_scatterChart;
-
-                chart.xAxis
-                    .tickFormat(d3.format(',.02f'));
-                chart.yAxis
-                    .tickFormat(d3.format(',.02f'));
-
-                chart.tooltipContent(function(key, y, e, graph) {
-                    var x = String(graph.point.x);
-                    var y = String(graph.point.y);
-                                        if(key == 'series 1'){
-                        var y =  String(graph.point.y)  + ' call';
-                    }
-                    if(key == 'series 2'){
-                        var y =  String(graph.point.y)  + ' min';
-                    }
-
-                    tooltip_str = '<center><b>'+key+'</b></center>' + y + ' at ' + x;
-                    return tooltip_str;
-                });
-
-        chart.showLegend(true);
-
-        chart
-        .showDistX(true)
-        .showDistY(true)
-        .color(d3.scale.category10().range());
-
-            d3.select('#scatterChart svg')
-                .datum(datum)
-                .transition().duration(500)
-                .attr('width', 400)
-                .attr('height', 400)
-                .call(chart);
-        });
-        </script>
+    .. include:: ./examples/scatterChart.html
 
     """
 

--- a/nvd3/stackedAreaChart.py
+++ b/nvd3/stackedAreaChart.py
@@ -30,47 +30,11 @@ class stackedAreaChart(TemplateMixin, NVD3Chart):
         chart.add_serie(name="Serie 1", y=ydata, x=xdata, extra=extra_serie)
         chart.add_serie(name="Serie 2", y=ydata2, x=xdata, extra=extra_serie)
         chart.buildhtml()
+        print(chart.content)
 
     Javascript generated:
 
-    .. raw:: html
-
-        <div id="stackedAreaChart"><svg style="height:450px; width:100%"></svg></div>
-        <script>
-
-
-            data_stackedAreaChart=[{"values": [{"y": 6, "x": 100}, {"y": 11, "x": 101}, {"y": 12, "x": 102}, {"y": 7, "x": 103}, {"y": 11, "x": 104}, {"y": 10, "x": 105}, {"y": 11, "x": 106}], "key": "Serie 1", "yAxis": "1"}, {"values": [{"y": 8, "x": 100}, {"y": 20, "x": 101}, {"y": 16, "x": 102}, {"y": 12, "x": 103}, {"y": 20, "x": 104}, {"y": 28, "x": 105}, {"y": 28, "x": 106}], "key": "Serie 2", "yAxis": "1"}];
-            nv.addGraph(function() {
-                var chart = nv.models.stackedAreaChart();
-                chart.margin({top: 30, right: 60, bottom: 20, left: 60});
-                var datum = data_stackedAreaChart;
-                        chart.xAxis
-                            .tickFormat(d3.format(',.2f'));
-                        chart.yAxis
-                            .tickFormat(d3.format(',.2f'));
-
-                        chart.tooltipContent(function(key, y, e, graph) {
-                            var x = String(graph.point.x);
-                            var y = String(graph.point.y);
-                                                if(key == 'Serie 1'){
-                                var y = 'There is ' +  String(graph.point.y)  + ' min';
-                            }
-                            if(key == 'Serie 2'){
-                                var y = 'There is ' +  String(graph.point.y)  + ' min';
-                            }
-
-                            tooltip_str = '<center><b>'+key+'</b></center>' + y + ' at ' + x;
-                            return tooltip_str;
-                        });
-                    chart.showLegend(true);
-                d3.select('#stackedAreaChart svg')
-                    .datum(datum)
-                    .transition().duration(500)
-                    .attr('width', 400)
-                    .attr('height', 400)
-                    .call(chart);
-            });
-        </script>
+    .. include:: ./examples/stackedAreaChart.html
 
     """
 

--- a/tests.py
+++ b/tests.py
@@ -79,7 +79,7 @@ class ChartTest(unittest.TestCase):
 
         chart.buildhtml()
 
-        assert("tooltip_str =" in chart.htmlcontent)
+        assert(".tickFormat(d3.format(',.02f'));" in chart.htmlcontent)
 
     def test_linePlusBarChart(self):
         """Test line Plus Bar Chart"""
@@ -201,7 +201,7 @@ class ChartTest(unittest.TestCase):
 
         # We don't modify the xAxis, so make sure that it's not invoked.
         assert("chart.xAxis" in chart.htmlcontent)
-        assert("tooltip_str =" in chart.htmlcontent)
+        assert("var chart = nv.models.discreteBarChart();" in chart.htmlcontent)
 
     def test_pieChart(self):
         """Test Pie Chart"""


### PR DESCRIPTION
Fix for part of the issues in #165 

I have fixed the tests (by not checking tooltip string anymore)
and added (a bit hacky) script for generating HTML examples into separate files, which are included into the docs.