### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/nvd3/NVD3Chart.py
+++ b/nvd3/NVD3Chart.py
@@ -45,7 +45,7 @@ class NVD3Chart(object):
     #:  directory holding the assets (bower_components)
     assets_directory = './bower_components/'
 
-    # this attribute is overriden by children of this
+    # this attribute is overridden by children of this
     # class
     CHART_FILENAME = None
     template_environment = Environment(lstrip_blocks=True, trim_blocks=True,

--- a/nvd3/bulletChart.py
+++ b/nvd3/bulletChart.py
@@ -17,7 +17,7 @@ class bulletChart(TemplateMixin, NVD3Chart):
     A bullet chart is a variation of a bar graph
     used to indicate the value of a single variable
     in relation to a set of qualitative ranges. It is
-    inspired by a dashboard guage or thermometer chart.
+    inspired by a dashboard gauge or thermometer chart.
 
     Python example:
 

--- a/nvd3/ipynb.py
+++ b/nvd3/ipynb.py
@@ -71,7 +71,7 @@ if _ip and _ip.__module__.lower().startswith('ipy'):
                         rel="stylesheet"/>''' % (nvd3_css_url)))
         # The following two methods for loading the script file are redundant.
         # This is intentional.
-        # Ipython's loading of javscript in version 1.x is a bit squirrely, especially
+        # Ipython's loading of javascript in version 1.x is a bit squirrely, especially
         # when creating demos to view in nbviewer.
         # by trying twice, in two different ways (one using jquery and one using plain old
         # HTML), we maximize our chances of successfully loading the script.

--- a/nvd3/multiChart.py
+++ b/nvd3/multiChart.py
@@ -36,7 +36,7 @@ class multiChart(TemplateMixin, NVD3Chart):
         chart.buildhtml()
 
 
-    Javascript renderd to:
+    Javascript rendered to:
 
     .. raw:: html
 


### PR DESCRIPTION
There are small typos in:
- nvd3/NVD3Chart.py
- nvd3/bulletChart.py
- nvd3/ipynb.py
- nvd3/multiChart.py

Fixes:
- Should read `rendered` rather than `renderd`.
- Should read `overridden` rather than `overriden`.
- Should read `javascript` rather than `javscript`.
- Should read `gauge` rather than `guage`.

Closes #170