### PR TITLE
Fix CI and update for recent python releases

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -31,6 +31,6 @@ jobs:
       run: coverage run --source=nvd3 -m unittest
 
     - name: Finish coveralls
-      run: coveralls
+      run: coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
       fail-fast: false
 
     steps:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
       fail-fast: false
 
     steps:
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -28,7 +28,7 @@ jobs:
         pip install coveralls
 
     - name: Run tests
-      run: coverage run --source=nvd3 setup.py test
+      run: coverage run --source=nvd3 -m unittest
 
     - name: Finish coveralls
       run: coveralls

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',


### PR DESCRIPTION
It looks like recent releases of setuptools have caused the CI to bitrot a little. `setup.py test` no longer works, so I had to replace that with an explicit `unittest` invocation. Recent versions of setuptools also complain about the license trove classifier, so I removed that.

I also dropped Python 3.7 tests (it's not installable on recent setup-python versions) and added 3.13, 3.14, and 3.14t tests.